### PR TITLE
Correction to use Arming rather than Pending state

### DIFF
--- a/custom_components/loxone/alarm_control_panel.py
+++ b/custom_components/loxone/alarm_control_panel.py
@@ -11,7 +11,7 @@ from homeassistant.components.alarm_control_panel.const import (
 from homeassistant.const import (CONF_CODE, CONF_NAME, CONF_PASSWORD,
                                  CONF_USERNAME, STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
-                                 STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED)
+                                 STATE_ALARM_ARMING, STATE_ALARM_TRIGGERED)
 
 from . import LoxoneEntity
 from .const import DOMAIN, EVENT, SECUREDSENDDOMAIN, SENDDOMAIN
@@ -215,7 +215,7 @@ class LoxoneAlarm(LoxoneEntity, AlarmControlPanelEntity):
         if self._level >= 1.0:
             return STATE_ALARM_TRIGGERED
         if self._armed_delay:
-            return STATE_ALARM_PENDING
+            return STATE_ALARM_ARMING
         if self._state and self._disabled_move:
             return STATE_ALARM_ARMED_HOME
         if self._state:


### PR DESCRIPTION
While testing spotted I used the wrong HomeAssistant state for the arming stage. Have now switched it to use `STATE_ALARM_ARMING`. 

I've tested the dev branch and I'm happy that it's working as expected. The states of the loxone alarm now follow the conventions described here: https://www.home-assistant.io/integrations/manual/. I don't think there is a concept of a 'pending' alarm in Loxone so I haven't tried to implement that.

So the sequence is `Disarmed` -> `Arming` -> `Armed Away`/`Armed Home` -> '`Triggered`, and then the `Level` attribute indicates what stage the alarm is at once triggered. 