### PR TITLE
Support for SHA1 visual passwords on version 12 server

### DIFF
--- a/custom_components/loxone/api.py
+++ b/custom_components/loxone/api.py
@@ -271,16 +271,20 @@ class LoxWs:
     async def send_secured(self, device_uuid, value, code):
         from Crypto.Hash import HMAC, SHA1, SHA256
         pwd_hash_str = code + ":" + self._visual_hash.salt
-        if self._visual_hash.hash_alg == "SHA1" or self._version < 12.0:
+        if self._visual_hash.hash_alg == "SHA1":
             m = hashlib.sha1()
-        else:
+        elif self._visual_hash.hash_alg == "SHA256":
             m = hashlib.sha256()
+        else:
+            _LOGGER.error("Unrecognised hash algorithm: {}".format(self._visual_hash.hash_alg))
+            return -1
+
         m.update(pwd_hash_str.encode('utf-8'))
         pwd_hash = m.hexdigest().upper()
-        if self._visual_hash.hash_alg == "SHA1" or self._version < 12.0:
+        if self._visual_hash.hash_alg == "SHA1":
             digester = HMAC.new(binascii.unhexlify(self._visual_hash.key),
                                 pwd_hash.encode("utf-8"), SHA1)
-        else:
+        elif self._visual_hash.hash_alg == "SHA256":
             digester = HMAC.new(binascii.unhexlify(self._visual_hash.key),
                             pwd_hash.encode("utf-8"), SHA256)
 
@@ -540,12 +544,16 @@ class LoxWs:
                 if "value" in resp_json['LL']:
                     key = resp_json['LL']['value']
                     if key != "":
-                        if self._token.hash_alg == "SHA1" or self._version < 12.0:
+                        if self._token.hash_alg == "SHA1":
                             digester = HMAC.new(binascii.unhexlify(key),
                                                 self._token.token.encode("utf-8"), SHA1)
-                        else:
+                        elif self._token.hash_alg == "SHA256":
                             digester = HMAC.new(binascii.unhexlify(key),
                                             self._token.token.encode("utf-8"), SHA256)
+                        else:
+                            _LOGGER.error("Unrecognised hash algorithm: {}".format(self._token.hash_alg))
+                            return ERROR_VALUE
+
                         return digester.hexdigest()
             return ERROR_VALUE
         except:
@@ -684,20 +692,25 @@ class LoxWs:
         try:
             from Crypto.Hash import HMAC, SHA1, SHA256
             pwd_hash_str = self._pasword + ":" + key_salt.salt
-            if key_salt.hash_alg == "SHA1" or self._version < 12.0 :
+            if key_salt.hash_alg == "SHA1":
                 m = hashlib.sha1()
-            else:
+            elif key_salt.hash_alg == "SHA256":
                 m = hashlib.sha256()
+            else:
+                _LOGGER.error("Unrecognised hash algorithm: {}".format(key_salt.hash_alg))
+                return None
+
             m.update(pwd_hash_str.encode('utf-8'))
             pwd_hash = m.hexdigest().upper()
             pwd_hash = self._username + ":" + pwd_hash
 
-            if key_salt.hash_alg == "SHA1" or self._version < 12.0:
+            if key_salt.hash_alg == "SHA1":
                 digester = HMAC.new(binascii.unhexlify(key_salt.key),
                                     pwd_hash.encode("utf-8"), SHA1)
-            else:
+            elif key_salt.hash_alg == "SHA256":
                 digester = HMAC.new(binascii.unhexlify(key_salt.key),
                                 pwd_hash.encode("utf-8"), SHA256)
+
             _LOGGER.debug("hash_credentials successfully...")
             return digester.hexdigest()
         except ValueError:
@@ -839,10 +852,10 @@ class LxJsonKeySalt:
         value = js['LL']['value']
         self.key = value['key']
         self.salt = value['salt']
-        self.hash_alg = value.get("hashAlg", "SHA256")
+        self.hash_alg = value.get("hashAlg", "SHA1")
 
 class LxToken:
-    def __init__(self, token="", vaild_until="", hash_alg="SHA256"):
+    def __init__(self, token="", vaild_until="", hash_alg="SHA1"):
         self._token = token
         self._vaild_until = vaild_until
         self._hash_alg = hash_alg

--- a/custom_components/loxone/api.py
+++ b/custom_components/loxone/api.py
@@ -271,13 +271,13 @@ class LoxWs:
     async def send_secured(self, device_uuid, value, code):
         from Crypto.Hash import HMAC, SHA1, SHA256
         pwd_hash_str = code + ":" + self._visual_hash.salt
-        if self._version < 12.0:
+        if self._visual_hash.hash_alg == "SHA1" or self._version < 12.0:
             m = hashlib.sha1()
         else:
             m = hashlib.sha256()
         m.update(pwd_hash_str.encode('utf-8'))
         pwd_hash = m.hexdigest().upper()
-        if self._version < 12.0:
+        if self._visual_hash.hash_alg == "SHA1" or self._version < 12.0:
             digester = HMAC.new(binascii.unhexlify(self._visual_hash.key),
                                 pwd_hash.encode("utf-8"), SHA1)
         else:
@@ -427,8 +427,7 @@ class LoxWs:
                     if 'value' in resp_json['LL']:
                         if 'key' in resp_json['LL']['value'] and 'salt' in resp_json['LL']['value']:
                             key_and_salt = LxJsonKeySalt()
-                            key_and_salt.key = resp_json['LL']['value']['key']
-                            key_and_salt.salt = resp_json['LL']['value']['salt']
+                            key_and_salt.read_user_salt_responce(parsed_data)
                             key_and_salt.time_elapsed_in_seconds = time_elapsed_in_seconds()
                             self._visual_hash = key_and_salt
 


### PR DESCRIPTION
After upgrading to version 12 of Loxone server, the alarm controls stopped working. i.e. it was no longer possible to arm or disarm the alarm. The only error in the logs was that a `"Code": "500"` response which according to the logs indicates the password was incorrect.

After debugging, identified that the server indicated the visual password was hashed using SHA1, but the logic in api.py was hardcoded to use SHA256 if version >= 12.0

After more investigation and reading the Loxone API docs, I think that the SHA is defined by server version that created the user record, so a version 12 server can contain both SHA1 and SHA256 user records. 

Possibly reseting the password would be a workaround, but it's easy enough to recognise the `hashAlg` returned by the Loxone server and apply it appropriately.

I've tested with both a SHA1 and SHA256 user and it's now working for me with these changes
