### PR TITLE
Prevent accidentally turning lights out

### DIFF
--- a/custom_components/loxone/light.py
+++ b/custom_components/loxone/light.py
@@ -309,7 +309,7 @@ class LoxonelightcontrollerV2(LoxoneEntity, LightEntity):
         if ATTR_EFFECT in kwargs:
             self.got_effect(**kwargs)
         elif kwargs == {}:
-            self.hass.bus.async_fire(SENDDOMAIN, dict(uuid=self.uuidAction, value="plus"))
+            self.hass.bus.async_fire(SENDDOMAIN, dict(uuid=self.uuidAction, value="on"))
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs) -> None:


### PR DESCRIPTION
if a light is already on and the service "light.turn_on" is used again