### PR TITLE
return correct device_class for Shutter Jalousie

### DIFF
--- a/custom_components/loxone/cover.py
+++ b/custom_components/loxone/cover.py
@@ -492,12 +492,14 @@ class LoxoneJalousie(LoxoneEntity, CoverEntity):
     @property
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
-        if self.animation in [0, 1]:
+        if self.animation == 0:
             return CoverDeviceClass.BLIND
+        if self.animation == 1:
+            return CoverDeviceClass.SHUTTER
         elif self.animation in [2, 4, 5]:
             return CoverDeviceClass.CURTAIN
         elif self.animation == 3:
-            return CoverDeviceClass.SHUTTER
+            return CoverDeviceClass.SHUTTER #not supported in newer versions (Schlotterer Retrolux)
         elif self.animation == 6:
             return CoverDeviceClass.AWNING
 


### PR DESCRIPTION
animation
○ The animation type of the JalousieControl
■ 0 = Blinds
■ 1 = Shutters
■ 2 = Curtain both sides
■ 3 = Not supported
■ 4 = Curtain Left
■ 5 = Curtain Right