### PR TITLE
Edit temperature unit

### DIFF
--- a/custom_components/loxone/fan.py
+++ b/custom_components/loxone/fan.py
@@ -118,7 +118,7 @@ async def async_setup_entry(
         #         "cat": fan.get("cat", ""),
         #         "name": fan["name"] + " - Temperature",
         #         "details": {
-        #             "format": "%.1f°"
+        #             "format": "%.1f°C"
         #         },
         #         "async_add_devices": async_add_entities
         #     }
@@ -131,7 +131,7 @@ async def async_setup_entry(
                 "room": fan.get("room", ""),
                 "cat": fan.get("cat", ""),
                 "name": fan["name"] + " - Temperature",
-                "details": {"format": "%.1f°"},
+                "details": {"format": "%.1f°C"},
                 "device_class": "temperature",
                 "async_add_devices": async_add_entities,
                 "config_entry": config_entry,


### PR DESCRIPTION
Fixes this warning

```
Entity fan.ventilatie_demokoffer_temperature (<class 'custom_components.loxone.sensor.Loxonesensor'>) is using native unit of measurement '°' which is not a valid unit for the device class ('temperature') it is using; expected one of ['°C', 'K', '°F']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/JoDehli/PyLoxone/issues
```