### PR TITLE
Integrate VI's that are not configured as DI

### DIFF
--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -185,6 +185,11 @@ async def async_setup_entry(
         sensor = add_room_and_cat_to_value_values(loxconfig, sensor)
         sensors.append(LoxoneTextSensor(**sensor))
 
+    for sensor in get_all(loxconfig, "Slider"):
+        sensor = add_room_and_cat_to_value_values(loxconfig, sensor)
+        sensor.update({"typ": "analog"})
+        sensors.append(Loxonesensor(**sensor))  
+
     @callback
     def async_add_sensors(_):
         async_add_entities(_, True)


### PR DESCRIPTION
In the current version, VI's are integrated in HA when they are configured as Digital Input in Loxone Config.

This PR enables the integration of VI's that are not configured as DI, for example numeric values.