### PR TITLE
Add integration of non-digital VI's

### DIFF
--- a/custom_components/loxone/__init__.py
+++ b/custom_components/loxone/__init__.py
@@ -258,6 +258,7 @@ async def async_setup_entry(hass, config_entry):
                     climates = []
                     fans = []
                     accontrols = []
+                    numbers = []
 
                     for s in entity_ids:
                         s_dict = s.as_dict()
@@ -282,6 +283,8 @@ async def async_setup_entry(hass, config_entry):
                                 fans.append(s_dict["entity_id"])
                             elif device_typ == "AcControl":
                                 accontrols.append(s_dict["entity_id"])
+                            elif device_typ == "Slider":
+                                numbers.append(s_dict["entity_id"])                            
 
                     sensors_analog.sort()
                     sensors_digital.sort()
@@ -292,6 +295,7 @@ async def async_setup_entry(hass, config_entry):
                     dimmers.sort()
                     fans.sort()
                     accontrols.sort()
+                    numbers.sort()
 
                     await create_group_for_loxone_enties(
                         hass, sensors_analog, "Loxone Analog Sensors", "loxone_analog"
@@ -329,6 +333,9 @@ async def async_setup_entry(hass, config_entry):
                         "Loxone AC Controllers",
                         "loxone_accontrollers",
                     )
+                    await create_group_for_loxone_enties(
+                        hass, numbers, "Loxone Numbers", "loxone_numbers"
+                    )                                      
                     await hass.async_block_till_done()
                     await create_group_for_loxone_enties(
                         hass,
@@ -339,6 +346,7 @@ async def async_setup_entry(hass, config_entry):
                             "group.loxone_covers",
                             "group.loxone_lights",
                             "group.loxone_ventilations",
+                            "group.loxone_numbers",
                         ],
                         "Loxone Group",
                         "loxone_group",

--- a/custom_components/loxone/number.py
+++ b/custom_components/loxone/number.py
@@ -72,6 +72,7 @@ class LoxoneNumber(LoxoneEntity, NumberEntity):
         self._assumed = False
         self._native_max_value = kwargs["details"]["max"]
         self._native_min_value = kwargs["details"]["min"]
+        self._native_step = kwargs["details"]["step"]
 
     @property
     def should_poll(self):
@@ -93,6 +94,10 @@ class LoxoneNumber(LoxoneEntity, NumberEntity):
         """Return the native_min_value to use for device if any."""
         return self._native_min_value
 
+    @property
+    def native_step(self):
+        """Return the native_min_value to use for device if any."""
+        return self._native_step
 
     @property
     def assumed_state(self):

--- a/custom_components/loxone/number.py
+++ b/custom_components/loxone/number.py
@@ -1,0 +1,151 @@
+"""
+Loxone Numbers
+
+For more details about this component, please refer to the documentation at
+https://github.com/JoDehli/PyLoxone
+"""
+import logging
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from . import LoxoneEntity
+from .const import DOMAIN, SENDDOMAIN
+from .helpers import (get_all, get_cat_name_from_cat_uuid,get_room_name_from_room_uuid)
+from .miniserver import get_miniserver_from_hass
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up Loxone Number."""
+    return True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up entry."""
+    miniserver = get_miniserver_from_hass(hass)
+    loxconfig = miniserver.lox_config.json
+    entites = []
+
+    for number_entity in get_all(
+        loxconfig, ["Slider"]
+    ):    
+        number_entity.update(
+            {
+                "room": get_room_name_from_room_uuid(
+                    loxconfig, number_entity.get("room", "")
+                ),
+                "cat": get_cat_name_from_cat_uuid(
+                    loxconfig, number_entity.get("cat", "")
+                ),
+                "config_entry": config_entry,
+            }
+        )
+        new_number = LoxoneNumber(**number_entity)
+        entites.append(new_number)
+
+    async_add_entities(entites)
+
+class LoxoneNumber(LoxoneEntity, NumberEntity):
+    """Representation of a loxone number"""
+
+    def __init__(self, **kwargs):
+        LoxoneEntity.__init__(self, **kwargs)
+        """Initialize the Loxone number."""
+        self._state = STATE_UNKNOWN
+        self._icon = None
+        self._assumed = False
+        self._native_max_value = kwargs["details"]["max"]
+        self._native_min_value = kwargs["details"]["min"]
+
+    @property
+    def should_poll(self):
+        """No polling needed for a demo number."""
+        return False
+
+    @property
+    def icon(self):
+        """Return the icon to use for device if any."""
+        return self._icon
+
+    @property
+    def native_max_value(self):
+        """Return the native_max_value to use for device if any."""
+        return self._native_max_value
+
+    @property
+    def native_min_value(self):
+        """Return the native_min_value to use for device if any."""
+        return self._native_min_value
+
+
+    @property
+    def assumed_state(self):
+        """Return if the state is based on assumptions."""
+        return self._assumed
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        return self._state        
+
+    async def event_handler(self, e):
+        if self.uuidAction in e.data:
+            data = e.data[self.uuidAction]
+            if isinstance(data, (list, dict)):
+                data = str(data)
+                if len(data) >= 255:
+                    self._state = data[:255]
+                else:
+                    self._state = data
+            else:
+                self._state = data
+
+            self.schedule_update_ha_state()
+
+    @property
+    def extra_state_attributes(self):
+        """Return device specific state attributes.
+
+        Implemented by platform classes.
+        """
+        return {
+            "uuid": self.uuidAction,
+            "state_uuid": self.states["value"],
+            "room": self.room,
+            "category": self.cat,
+            "device_typ": self.type,
+            "platform": "loxone",
+        }
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "manufacturer": "Loxone",
+            "model": self.type,
+            "suggested_area": self.room,
+        }
+
+    async def async_set_native_value(self, value: float):
+        """Set new value."""
+        self.hass.bus.async_fire(
+            SENDDOMAIN, dict(uuid=self.uuidAction, value="{}".format(value))
+        )
+        self.async_schedule_update_ha_state()


### PR DESCRIPTION
This code aims to integrate VI's that are configured as being non-digital.

VI's configured this way, enable easy transfer of numerical data from HA to Loxone (and vice-versa).
The code implements this using Number-entities and considers the `min`, `max` and `step` parameters in Loxone.

The type of Number is determined by Home Assistant.

In my use case, I use this to:

- Send P1 digital meter data to Loxone, since Loxone has no supported P1 interface. HA does, using the DSMR integration
- Get the level of the rainwater storage tank. This is a very noisy signal, and H1 does a great job filtering this. The filtered value is then sent to Loxone.

![image](https://github.com/JoDehli/PyLoxone/assets/65073191/22ba85af-d526-48f7-a3e0-67193ea2db97)
![image](https://github.com/JoDehli/PyLoxone/assets/65073191/78aed540-ce3a-4f48-8dc0-64726eca2afc)
