### PR TITLE
fixed AttributeError on LoxoneCustomSensor

### DIFF
--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -189,7 +189,7 @@ async def async_setup_entry(
 
 class LoxoneCustomSensor(LoxoneEntity, SensorEntity):
     def __init__(self, **kwargs):
-        LoxoneEntity().__init__(**kwargs)
+        LoxoneEntity(**kwargs)
         self._name = kwargs["name"]
         if "uuidAction" in kwargs:
             self.uuidAction = kwargs["uuidAction"]


### PR DESCRIPTION
With PyLoxone 0.6.6 and HA 2024.5.0 I was not able to use a `LoxoneCustomSensor` any more. The sensors are configured in file `configuration.yaml` as described in the README. The exception during startup was:
```text
2024-05-03 18:36:27.004 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up loxone platform for sensor
Traceback (most recent call last):
  File "/Users/juerg.luthiger/projects-dev/home-assistant/core/homeassistant/helpers/entity_platform.py", line 356, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/Users/juerg.luthiger/projects-dev/home-assistant/core/config/custom_components/loxone/sensor.py", line 151, in async_setup_platform
    new_sensor = LoxoneCustomSensor(**config)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/juerg.luthiger/projects-dev/home-assistant/core/config/custom_components/loxone/sensor.py", line 192, in __init__
    LoxoneEntity().__init__(**kwargs)
    ^^^^^^^^^^^^^^
  File "/Users/juerg.luthiger/projects-dev/home-assistant/core/config/custom_components/loxone/__init__.py", line 431, in __init__
    self._attr_name = self.name
                      ^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/juerg.luthiger/projects-dev/home-assistant/core/config/custom_components/loxone/__init__.py", line 447, in name
    return self._attr_name
           ^^^^^^^^^^^^^^^
AttributeError: 'LoxoneEntity' object has no attribute '__attr_name'. Did you mean: '_attr_name'?
```