### PR TITLE
Setting _is_closing instead of _is_opening when a cover is closing.

### DIFF
--- a/custom_components/loxone/cover.py
+++ b/custom_components/loxone/cover.py
@@ -205,7 +205,7 @@ class LoxoneGate(LoxoneEntity, CoverEntity):
                 self._is_opening = False
 
                 if event.data[self._state_uuid] == -1:
-                    self._is_opening = True
+                    self._is_closing = True
                 elif event.data[self._state_uuid] == 1:
                     self._is_opening = True
             self.schedule_update_ha_state()


### PR DESCRIPTION
This PR addresses a bug where the cover was incorrectly displayed as "opening" even when it was "closing." The status logic has been corrected to represent the cover's current state accurately.