### PR TITLE
allow higher version of websockets to avoid clash with core ring

### DIFF
--- a/custom_components/loxone/manifest.json
+++ b/custom_components/loxone/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JoDehli/PyLoxone/issues",
   "requirements": [
-    "websockets==11.0.1",
+    "websockets>=11.0.1,<14",
     "pycryptodome",
     "numpy",
     "httpx"


### PR DESCRIPTION
fixes issue https://github.com/JoDehli/PyLoxone/issues/334

will stop integration from causing core ring integration to fail after 2024.11.2 upgrade

allows websockets version to increase but not to 14 or above as that may introduce breaking changes.
It should be tested and updated as needed to support higher versions.