### PR TITLE
Reload integration from UI & bugfix

### DIFF
--- a/custom_components/loxone/__init__.py
+++ b/custom_components/loxone/__init__.py
@@ -84,6 +84,12 @@ async def async_unload_entry(hass, config_entry):
     if miniserver:
         await miniserver.stop_loxone()  # Stop any ongoing tasks or WebSocket connections.
 
+    hass.services.async_remove(DOMAIN, "event_websocket_command")
+    hass.services.async_remove(DOMAIN, "event_secured_websocket_command")
+    hass.services.async_remove(DOMAIN, "sync_areas")
+
+    hass.data.pop(DOMAIN, None)
+
     # Unload platforms
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, LOXONE_PLATFORMS

--- a/custom_components/loxone/api.py
+++ b/custom_components/loxone/api.py
@@ -189,7 +189,6 @@ class LoxWs:
             if "softwareVersion" in self._loxconfig:
                 vers = self._loxconfig["softwareVersion"]
                 if isinstance(vers, list) and len(vers) >= 2:
-                    _LOGGER.warn(vers)
                     try:
                         self._version = float("{}.{}".format(vers[0], vers[1]))
                     except ValueError:

--- a/custom_components/loxone/climate.py
+++ b/custom_components/loxone/climate.py
@@ -285,13 +285,6 @@ class LoxoneRoomControllerV2(LoxoneEntity, ClimateEntity, ABC):
 class LoxoneAcControl(LoxoneEntity, ClimateEntity, ABC):
     """Representation of a ACControl Loxone device."""
 
-    attr_supported_features = (
-        ClimateEntityFeature.PRESET_MODE
-        | ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
-    )
-
     def __init__(self, **kwargs):
         _LOGGER.debug(f"Input AcControl: {kwargs}")
         super().__init__(**kwargs)
@@ -304,8 +297,16 @@ class LoxoneAcControl(LoxoneEntity, ClimateEntity, ABC):
             self.unique_id, self.name, self.type, self.room
         )
 
+    @property
+    def supported_features(self) -> int:
+        """Return the supported features."""
+        return (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TURN_ON
+        )
+
     async def event_handler(self, event):
-        # _LOGGER.debug(f"Climate Event data: {event.data}")
         update = False
 
         for key in set(self._stateAttribUuids.values()) & event.data.keys():
@@ -314,9 +315,6 @@ class LoxoneAcControl(LoxoneEntity, ClimateEntity, ABC):
 
         if update:
             self.schedule_update_ha_state()
-
-        # _LOGGER.debug(f"State attribs after event handling: {self._stateAttribValues}")
-
     def get_state_value(self, name):
         uuid = self._stateAttribUuids[name]
         return (

--- a/custom_components/loxone/climate.py
+++ b/custom_components/loxone/climate.py
@@ -307,14 +307,15 @@ class LoxoneAcControl(LoxoneEntity, ClimateEntity, ABC):
         )
 
     async def event_handler(self, event):
+        # _LOGGER.debug(f"Climate Event data: {event.data}")
         update = False
-
         for key in set(self._stateAttribUuids.values()) & event.data.keys():
             self._stateAttribValues[key] = event.data[key]
             update = True
-
         if update:
             self.schedule_update_ha_state()
+        # _LOGGER.debug(f"State attribs after event handling: {self._stateAttribValues}")
+  
     def get_state_value(self, name):
         uuid = self._stateAttribUuids[name]
         return (

--- a/custom_components/loxone/const.py
+++ b/custom_components/loxone/const.py
@@ -22,6 +22,7 @@ LOXONE_PLATFORMS: Final[list[Platform]] = [
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.BUTTON,
+    Platform.SCENE,
 ]
 
 LOXONE_DEFAULT_PORT = 8080


### PR DESCRIPTION
A small update for the integration that should make using it a lot more convenient:

**__init.py__**

- Implement `async_unload_entry` to enable reloading the integration
- Add `remove_unavailable_entities` and `remove_unused_devices` to avoind orphaned devices/entities when function blocks are removed in Config.
- Removed loading the SCENE platform and let it load as a standard platform from const.py

**api.py**

Add reconnect try/catch to avoid connecting to MS after the connection was closed

**climate.py**

Solve this warning:
```
Entity None (<class 'custom_components.loxone.climate.LoxoneAcControl'>) implements HVACMode(s): off, auto and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/JoDehli/PyLoxone/issues
```

I tested this on my system and works when removing/adding function blocks in Config and then reloading the integration instead of rebooting HA.
Maybe someone else can try and test?