### PR TITLE
Add slightly more sophisticated room controller units detection

### DIFF
--- a/custom_components/loxone/climate.py
+++ b/custom_components/loxone/climate.py
@@ -223,11 +223,14 @@ class LoxoneRoomControllerV2(LoxoneEntity, ClimateEntity, ABC):
         # and default to Celsius if not.
         format_str = self.details.get("format")
 
-        if "°C" in format_str:
+        if format_str is None:
             return UnitOfTemperature.CELSIUS
 
-        if "°F" in format_str:
+        if "°F" in format_str or "F" in format_str:
             return UnitOfTemperature.FAHRENHEIT
+
+        if "°C" in format_str or "C" in format_str:
+            return UnitOfTemperature.CELSIUS
 
         return UnitOfTemperature.CELSIUS
 

--- a/custom_components/loxone/climate.py
+++ b/custom_components/loxone/climate.py
@@ -217,10 +217,18 @@ class LoxoneRoomControllerV2(LoxoneEntity, ClimateEntity, ABC):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement used by the platform."""
-        if "format" in self.details:
-            if self.details["format"].find("°"):
-                return UnitOfTemperature.CELSIUS
+        # The Loxone Config app allows the designer to set an arbitrary
+        # format string for the room controller's input temperature sensor.
+        # We assume that the format string contains the unit of temperature,
+        # and default to Celsius if not.
+        format_str = self.details.get("format")
+
+        if "°C" in format_str:
+            return UnitOfTemperature.CELSIUS
+
+        if "°F" in format_str:
             return UnitOfTemperature.FAHRENHEIT
+
         return UnitOfTemperature.CELSIUS
 
     @property


### PR DESCRIPTION
For #359 

This checks for `°F` and `°C` in the format string and uses those units of measure. If neither of those are present, it defaults to Celsius. 

There could be lots of other format strings, since they're arbitrary, but I think this is a good starting point.