### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/loxone/climate.py
+++ b/custom_components/loxone/climate.py
@@ -312,7 +312,7 @@ class LoxoneRoomController(LoxoneEntity, ClimateEntity, ABC):
 class LoxoneRoomControllerV2(LoxoneEntity, ClimateEntity, ABC):
     """Loxone room controller"""
 
-    attr_supported_features = (
+    _attr_supported_features = (
         ClimateEntityFeature.PRESET_MODE
         | ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.TURN_OFF
@@ -510,7 +510,7 @@ class LoxoneRoomControllerV2(LoxoneEntity, ClimateEntity, ABC):
 class LoxoneAcControl(LoxoneEntity, ClimateEntity, ABC):
     """Representation of a ACControl Loxone device."""
 
-    attr_supported_features = (
+    _attr_supported_features = (
         ClimateEntityFeature.PRESET_MODE
         | ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.TURN_OFF


### PR DESCRIPTION
This PR fixes a small bug (fix #416 ) in the climate entities:

- LoxoneRoomControllerV2
- LoxoneAcControl

They defined `attr_supported_features` instead of `_attr_supported_features`.
Because of that, Home Assistant didn't enable ClimateEntityFeature.TARGET_TEMPERATURE
(and others), even though `target_temperature` and `set_temperature` were already implemented.

With this change, both entities expose TARGET_TEMPERATURE correctly and the HA climate card
shows a target temperature control that works with the existing logic.
