### PR TITLE
Add Common Loxone Attributes to All Entities

### DIFF
--- a/custom_components/loxone/__init__.py
+++ b/custom_components/loxone/__init__.py
@@ -642,6 +642,18 @@ class LoxoneEntity(Entity):
 
         self.listener = None
 
+        # Initialize base extra state attributes with common Loxone fields
+        self._attr_extra_state_attributes = {
+            "uuid": kwargs.get("uuidAction", ""),
+            "platform": "loxone",
+        }
+
+        # Add optional common attributes from Loxone JSON if they exist
+        if "room" in kwargs and kwargs["room"]:
+            self._attr_extra_state_attributes["room"] = kwargs["room"]
+        if "cat" in kwargs and kwargs["cat"]:
+            self._attr_extra_state_attributes["category"] = kwargs["cat"]
+
     async def async_added_to_hass(self):
         """Subscribe to device events."""
         self.listener = self.hass.bus.async_listen(EVENT, self.event_handler)

--- a/custom_components/loxone/alarm_control_panel.py
+++ b/custom_components/loxone/alarm_control_panel.py
@@ -230,16 +230,13 @@ class LoxoneAlarm(LoxoneEntity, AlarmControlPanelEntity):
     def extra_state_attributes(self):
         """Return the state attributes."""
         return {
-            "uuid": self.uuidAction,
-            "room": self.room,
-            "category": self.cat,
+            **self._attr_extra_state_attributes,
             "device_type": self.type,
             "level": self._level,
             "armed_at": self._armed_at,
             "next_level_at": self._next_level_at,
             "armed_delay": self._armed_delay,
             "armed_delay_total_delay": self._armed_delay_total_delay,
-            "platform": "loxone",
         }
 
     def _validate_code(self, code):

--- a/custom_components/loxone/binary_sensor.py
+++ b/custom_components/loxone/binary_sensor.py
@@ -141,20 +141,14 @@ class LoxoneDigitalSensor(LoxoneEntity, BinarySensorEntity):
             )
 
         if self._from_loxone_config:
-            self._attr_extra_state_attributes = {
-                "uuid": self.uuidAction,
+            self._attr_extra_state_attributes.update({
                 "state_uuid": self._state_uuid,
-                "room": self.room,
-                "category": self.cat,
-                "device_typ": self.type,
-                "platform": "loxone",
-            }
+                "device_type": self.type,
+            })
         else:
-            self._attr_extra_state_attributes = {
-                "uuid": self.uuidAction,
-                "platform": "loxone",
-                "device_typ": self.device_class,
-            }
+            self._attr_extra_state_attributes.update({
+                "device_type": self.device_class,
+            })
 
     @property
     def icon(self):

--- a/custom_components/loxone/button.py
+++ b/custom_components/loxone/button.py
@@ -107,12 +107,9 @@ class LoxoneButton(LoxoneEntity, ButtonEntity):
     def extra_state_attributes(self):
         """Return device specific state attributes."""
         return {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "state_uuid": self.states["active"],
-            "room": self.room,
-            "category": self.cat,
             "device_type": self.type,
-            "platform": "loxone",
         }
 
     @property

--- a/custom_components/loxone/climate.py
+++ b/custom_components/loxone/climate.py
@@ -174,6 +174,7 @@ class LoxoneRoomController(LoxoneEntity, ClimateEntity, ABC):
     def extra_state_attributes(self):
         """Return device specific state attributes."""
         return {
+            **self._attr_extra_state_attributes,
             "mode": self.get_state_value("mode"),
             "override": self.get_state_value("override"),
             "open_window": self.get_state_value("openWindow"),
@@ -369,6 +370,7 @@ class LoxoneRoomControllerV2(LoxoneEntity, ClimateEntity, ABC):
         Implemented by platform classes.
         """
         return {
+            **self._attr_extra_state_attributes,
             "is_overridden": self.is_overridden,
         }
 
@@ -567,11 +569,8 @@ class LoxoneAcControl(LoxoneEntity, ClimateEntity, ABC):
         Implemented by platform classes.
         """
         return {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "device_type": self.type,
-            "room": self.room,
-            "category": self.cat,
-            "platform": "loxone",
         }
 
     @property

--- a/custom_components/loxone/cover.py
+++ b/custom_components/loxone/cover.py
@@ -217,10 +217,8 @@ class LoxoneGate(LoxoneEntity, CoverEntity):
         Implemented by platform classes.
         """
         return {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "device_type": self.type,
-            "category": self.cat,
-            "platform": "loxone",
         }
 
 
@@ -267,11 +265,8 @@ class LoxoneWindow(LoxoneEntity, CoverEntity):
         Implemented by platform classes.
         """
         device_att = {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "device_type": self.type,
-            "platform": "loxone",
-            "room": self.room,
-            "category": self.cat,
         }
         return device_att
 
@@ -530,11 +525,8 @@ class LoxoneJalousie(LoxoneEntity, CoverEntity):
         Implemented by platform classes.
         """
         device_att = {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "device_type": self.type,
-            "platform": "loxone",
-            "room": self.room,
-            "category": self.cat,
             "current_position": self.current_cover_position,
             "current_shade_mode": self.shade_postion_as_text,
             "current_position_loxone_style": round(self._position_loxone, 0),

--- a/custom_components/loxone/fan.py
+++ b/custom_components/loxone/fan.py
@@ -168,11 +168,8 @@ class LoxoneVentilation(LoxoneEntity, FanEntity):
         Implemented by platform classes.
         """
         return {
-            "uuid": self.uuidAction,
-            "room": self.room,
-            "category": self.cat,
+            **self._attr_extra_state_attributes,
             "device_type": self.type,
-            "platform": "loxone",
         }
 
     @property

--- a/custom_components/loxone/lights/dimmer.py
+++ b/custom_components/loxone/lights/dimmer.py
@@ -50,16 +50,12 @@ class LoxoneDimmer(LoxoneEntity, LightEntity):
             )
 
         state_attributes = {
-            "uuid": self.uuidAction,
-            "room": self.room,
-            "category": self.cat,
             "device_type": self.type,
-            "platform": "loxone",
         }
         if self._light_controller_name:
             state_attributes.update({"light_controller": self._light_controller_name})
 
-        self._attr_extra_state_attributes = state_attributes
+        self._attr_extra_state_attributes.update(state_attributes)
 
     @cached_property
     def unique_id(self) -> str:

--- a/custom_components/loxone/lights/lightcontroller.py
+++ b/custom_components/loxone/lights/lightcontroller.py
@@ -169,15 +169,12 @@ class LoxoneLightControllerV2(LoxoneEntity, LightEntity):
         Implemented by platform classes.
         """
         return {
-            "uuid": self.uuidAction,
-            "room": self.room,
-            "category": self.cat,
+            **self._attr_extra_state_attributes,
             "selected_scene": self.effect,
             "selected_scenes": [
                 self.get_moodname_by_id(id) for id in self._active_moods
             ],
             "device_type": self.type,
-            "platform": "loxone",
             "subcontrols": self._sub_controls,
         }
 

--- a/custom_components/loxone/lights/switch.py
+++ b/custom_components/loxone/lights/switch.py
@@ -40,16 +40,12 @@ class LoxoneLightSwitch(LoxoneEntity, LightEntity):
             )
 
         state_attributes = {
-            "uuid": self.uuidAction,
-            "room": self.room,
-            "category": self.cat,
             "device_type": self.type,
-            "platform": "loxone",
         }
         if self._light_controller_name:
             state_attributes.update({"light_controller": self._light_controller_name})
 
-        self._attr_extra_state_attributes = state_attributes
+        self._attr_extra_state_attributes.update(state_attributes)
 
     @cached_property
     def unique_id(self) -> str:

--- a/custom_components/loxone/number.py
+++ b/custom_components/loxone/number.py
@@ -125,10 +125,8 @@ class LoxoneNumber(LoxoneEntity, NumberEntity):
         Implemented by platform classes.
         """
         return {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "state_uuid": self.states["value"],
-            "room": self.room,
-            "category": self.cat,
             "device_type": self.type,
             "platform": "loxone",
         }

--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -269,10 +269,7 @@ class LoxoneCustomSensor(LoxoneEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return device specific state attributes."""
-        return {
-            "uuid": self.uuidAction,
-            "platform": "loxone",
-        }
+        return {**self._attr_extra_state_attributes}
 
 
 class LoxoneKeepAliveSensor(LoxoneEntity, SensorEntity):
@@ -307,9 +304,7 @@ class LoxoneKeepAliveSensor(LoxoneEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return device specific state attributes."""
-        return {
-            "platform": "loxone",
-        }
+        return {**self._attr_extra_state_attributes}
 
 
 class LoxoneVersionSensor(LoxoneEntity, SensorEntity):
@@ -364,10 +359,8 @@ class LoxoneTextSensor(LoxoneEntity, SensorEntity):
     def extra_state_attributes(self):
         """Return device specific state attributes."""
         return {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "device_type": self.type,
-            "platform": "loxone",
-            "category": self.cat,
         }
 
 
@@ -435,10 +428,8 @@ class LoxoneSensor(LoxoneEntity, SensorEntity):
     def extra_state_attributes(self):
         """Return device specific state attributes."""
         return {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "device_type": self.type + "_sensor",
-            "platform": "loxone",
-            "category": self.cat,
         }
 
 

--- a/custom_components/loxone/switch.py
+++ b/custom_components/loxone/switch.py
@@ -159,11 +159,8 @@ class LoxoneTimedSwitch(LoxoneEntity, SwitchEntity):
         Implemented by platform classes.
         """
         state_dict = {
-            "uuid": self.uuidAction,
-            "room": self.room,
-            "category": self.cat,
+            **self._attr_extra_state_attributes,
             "device_type": self.type,
-            "platform": "loxone",
         }
 
         if self._state == 0.0:

--- a/custom_components/loxone/text.py
+++ b/custom_components/loxone/text.py
@@ -114,12 +114,9 @@ class LoxoneText(LoxoneEntity, TextEntity):
         Implemented by platform classes.
         """
         return {
-            "uuid": self.uuidAction,
+            **self._attr_extra_state_attributes,
             "state_uuid": self.states["text"],
-            "room": self.room,
-            "category": self.cat,
             "device_type": self.type,
-            "platform": "loxone",
         }
 
     async def async_set_value(self, value: str):


### PR DESCRIPTION
Currently, entity attributes are inconsistently set across different entity types:
- **Missing important metadata** - Some entities don't expose `room` and `category` attributes, making it impossible to properly tag data in InfluxDB and other time-series databases
- **Inconsistent implementation** - Some entities expose these attributes, others don't, leading to incomplete data exports
- **Code duplication** - Similar attribute assignments repeated across 15+ entity classes
- Fixing a typo in a tag `device_typ` -> `device_type`

This PR centralizes common attribute handling in the base `LoxoneEntity` class, ensuring **all entities consistently expose room and category information** for proper InfluxDB tagging.
