### PR TITLE
fix(climate): use ATTR_TEMPERATURE key in AcControl.set_temperature (#479)

### DIFF
--- a/custom_components/loxone/climate.py
+++ b/custom_components/loxone/climate.py
@@ -582,11 +582,14 @@ class LoxoneAcControl(LoxoneEntity, ClimateEntity, ABC):
 
     def set_temperature(self, **kwargs):
         """Set new target temperature"""
+        temp = kwargs.get("temperature")
+        if temp is None:
+            return
         self.hass.bus.fire(
             SENDDOMAIN,
             dict(
                 uuid=self.uuidAction,
-                value=f'setTarget/{kwargs["targetTemperature"]}',
+                value=f"setTarget/{temp}",
             ),
         )
 


### PR DESCRIPTION
Fixes #479.

`AcControl.set_temperature` reads `kwargs["targetTemperature"]`, but Home Assistant's climate platform passes the new target as `kwargs["temperature"]` (`ATTR_TEMPERATURE`), causing every call to crash with `KeyError: 'targetTemperature'`. Other `set_temperature` methods in the same file (lines 196, 397) already read `kwargs["temperature"]` correctly.

Switches the AcControl path to the same pattern and guards against a missing value.