### PR TITLE
Fix logging format for unhandled commands

### DIFF
--- a/custom_components/loxone/lights/colorpickers.py
+++ b/custom_components/loxone/lights/colorpickers.py
@@ -101,7 +101,7 @@ class TunableWhiteLight(LoxoneEntity, LightEntity):
                 self._attr_brightness = round(255 * _color[0] / 100)
                 request_update = True
             else:
-                _LOGGER.error("Not handled command ->", _color)
+                _LOGGER.error("Not handled command -> %s", _color)
 
         if request_update:
             self.async_schedule_update_ha_state()

--- a/custom_components/loxone/lights/colorpickers.py
+++ b/custom_components/loxone/lights/colorpickers.py
@@ -240,7 +240,7 @@ class RGBColorPicker(LoxoneEntity, LightEntity):
                 self._attr_brightness = round(255 * _color[0] / 100)
                 request_update = True
             else:
-                _LOGGER.error("Not handled command ->", _color)
+                _LOGGER.error("Not handled command -> %s", _color)
 
         if request_update:
             self.async_schedule_update_ha_state()


### PR DESCRIPTION
Fixing overflow of log:

Traceback (most recent call last):
  File "/usr/local/lib/python3.14/logging/handlers.py", line 1512, in emit
    self.enqueue(self.prepare(record))
                 ~~~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.14/logging/handlers.py", line 1494, in prepare
    msg = self.format(record)
  File "/usr/local/lib/python3.14/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.14/logging/__init__.py", line 712, in format
    record.message = record.getMessage()
                     ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/logging/__init__.py", line 400, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 229, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 215, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 289, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 706, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 677, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 2046, in _run_once
    handle._run()
  File "/usr/local/lib/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
  File "/config/custom_components/loxone/pyloxone_api/connection.py", line 741, in _run_callback
    await callback(msg.as_dict())
  File "/config/custom_components/loxone/__init__.py", line 353, in message_callback
    hass.bus.async_fire(EVENT, message)
  File "/usr/src/homeassistant/homeassistant/core.py", line 1497, in async_fire
    return self.async_fire_internal(
  File "/usr/src/homeassistant/homeassistant/core.py", line 1550, in async_fire_internal
    self._hass.async_run_hass_job(job, event)
  File "/usr/src/homeassistant/homeassistant/core.py", line 915, in async_run_hass_job
    return self._async_add_hass_job(hassjob, *args, background=background)
  File "/usr/src/homeassistant/homeassistant/core.py", line 730, in _async_add_hass_job
    task = create_eager_task(
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 44, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/config/custom_components/loxone/lights/colorpickers.py", line 104, in event_handler
    _LOGGER.error("Not handled command ->", _color)
  File "/usr/local/lib/python3.14/logging/__init__.py", line 1549, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/usr/local/lib/python3.14/logging/__init__.py", line 1665, in _log
    self.handle(record)
  File "/usr/local/lib/python3.14/logging/__init__.py", line 1681, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.14/logging/__init__.py", line 1737, in callHandlers
    hdlr.handle(record)
  File "/usr/src/homeassistant/homeassistant/util/logging.py", line 113, in handle
    self.emit(record)
Message: 'Not handled command ->'
Arguments: ('hsv(0,0,0)',)