### PR TITLE
Adding compatibility for Python 3.14

### DIFF
--- a/custom_components/loxone/pyloxone_api/connection.py
+++ b/custom_components/loxone/pyloxone_api/connection.py
@@ -19,9 +19,9 @@ from types import TracebackType
 from typing import Any, NoReturn, Optional, Union
 from urllib.parse import urlparse
 
+import aiohttp
 import websockets as wslib
 import websockets.exceptions
-from async_upnp_client import aiohttp
 from Crypto.Cipher import AES, PKCS1_v1_5
 from Crypto.Hash import HMAC, SHA1, SHA256
 from Crypto.PublicKey import RSA
@@ -646,7 +646,11 @@ class LoxoneConnection(LoxoneBaseConnection):
         except asyncio.CancelledError:
             _LOGGER.debug("Listening task cancelled")
             raise
-        except LoxoneConnectionError, LoxoneTokenError, LoxoneConnectionClosedOk:
+        except (
+            LoxoneConnectionError,
+            LoxoneTokenError,
+            LoxoneConnectionClosedOk,
+        ):
             raise
         except Exception as e:
             raise
@@ -777,7 +781,11 @@ class LoxoneConnection(LoxoneBaseConnection):
         except asyncio.CancelledError:
             _LOGGER.debug("Listening task cancelled")
             raise
-        except LoxoneTokenError, LoxoneOutOfServiceException, LoxoneConnectionError:
+        except (
+            LoxoneTokenError,
+            LoxoneOutOfServiceException,
+            LoxoneConnectionError,
+        ):
             # Re-raise expected Loxone exceptions
             raise
         except Exception as e:

--- a/custom_components/loxone/pyloxone_api/message.py
+++ b/custom_components/loxone/pyloxone_api/message.py
@@ -75,7 +75,7 @@ def detect_encoding(byte_string):
         try:
             byte_string.decode(encoding)
             return encoding
-        except UnicodeDecodeError, AttributeError:
+        except (UnicodeDecodeError, AttributeError):
             continue
     return None
 

--- a/custom_components/loxone/pyloxone_api/tests/test_run_alone.py
+++ b/custom_components/loxone/pyloxone_api/tests/test_run_alone.py
@@ -13,10 +13,6 @@ def load_credentials_from_env():
         "port": os.getenv("LOXONE_PORT"),
     }
 
-
-load_credentials_from_env()
-
-
 def test_alone(load_credentials_from_env):
     pass
     # print("Username", username)

--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -474,7 +474,7 @@ class LoxoneMeterSensor(LoxoneSensor, SensorEntity):
         try:
             # For legacy Meter
             model = sensor["details"]["type"].capitalize() + " Meter"
-        except KeyError, TypeError:
+        except (KeyError, TypeError):
             model = "Meter"
         return DeviceInfo(
             identifiers={(DOMAIN, sensor["uuidAction"])},

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+markers =
+    online: tests that require network access or external services

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ ruff==0.14.6
 websockets>=14
 pycryptodome
 pytest
+pytest-asyncio
 httpx
 debugpy
 pre-commit
+python-dotenv

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py313"
+target-version = "py314"
 line-length = 120
 
 [lint]

--- a/tests/test_python_compatibility.py
+++ b/tests/test_python_compatibility.py
@@ -1,0 +1,31 @@
+"""Source-level compatibility checks for modern Python versions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEGACY_EXCEPT_PATTERN = re.compile(
+    r"except\s+[^\(\n:][^:\n]*,\s*[A-Za-z_][A-Za-z0-9_\.]*\s*:"
+)
+
+
+def test_no_legacy_comma_except_handlers_remain() -> None:
+    """Modern Python rejects ``except A, B:`` syntax."""
+    source_paths = ROOT.glob("custom_components/**/*.py")
+    offenders = [
+        str(path.relative_to(ROOT))
+        for path in source_paths
+        if LEGACY_EXCEPT_PATTERN.search(path.read_text(encoding="utf-8"))
+    ]
+
+    assert offenders == []
+
+
+def test_ruff_targets_python_314() -> None:
+    """Keep lint parsing aligned with the latest supported Python line."""
+    ruff_config = (ROOT / "ruff.toml").read_text(encoding="utf-8")
+
+    assert 'target-version = "py314"' in ruff_config


### PR DESCRIPTION
When Python is upgraded from Python 3.12 to Pytohn 3.14 (not sure at what step exactly), it seems that some Python 2 syntax which was tolerated earlier is not supported anymore. Particularly, comma separated exceptions without parantheses:

`except LoxoneConnectionError, LoxoneTokenError, LoxoneConnectionClosedOk:
`
which by now should be

```
except (
    LoxoneConnectionError,
    LoxoneTokenError,
    LoxoneConnectionClosedOk,
):
```

This merge request fixes those issues and creates compatibility to Python 3.14.



Specific failure HomeAssistant drops:

```
Setup failed for custom integration ‘loxone’: Unable to import component: Exception importing custom_components.loxone
 Traceback (most recent call last):
  File “/usr/src/homeassistant/homeassistant/loader.py”, line 1066, in _get_component
   ComponentProtocol, importlib.import_module(self.pkg_path)
             ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File “/usr/src/homeassistant/homeassistant/util/loop.py”, line 201, in protected_loop_func
   return func(*args, **kwargs)
  File “/usr/local/lib/python3.13/importlib/__init__.py”, line 88, in import_module
   return _bootstrap._gcd_import(name[level:], package, level)
       ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File “<frozen importlib._bootstrap>“, line 1387, in _gcd_import
  File “<frozen importlib._bootstrap>“, line 1360, in _find_and_load
  File “<frozen importlib._bootstrap>“, line 1331, in _find_and_load_unlocked
  File “<frozen importlib._bootstrap>“, line 935, in _load_unlocked
  File “<frozen importlib._bootstrap_external>“, line 1026, in exec_module
  File “<frozen importlib._bootstrap>“, line 488, in _call_with_frames_removed
  File “/config/custom_components/loxone/__init__.py”, line 38, in <module>
   from .coordinator import LoxoneCoordinator
  File “/config/custom_components/loxone/coordinator.py”, line 11, in <module>
   from .pyloxone_api.connection import LoxoneConnection, LoxoneException
  File “/config/custom_components/loxone/pyloxone_api/connection.py”, line 649
   except LoxoneConnectionError, LoxoneTokenError, LoxoneConnectionClosedOk:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 SyntaxError: multiple exception types must be parenthesized

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File “/usr/src/homeassistant/homeassistant/loader.py”, line 1006, in async_get_component
   comp = await self.hass.async_add_import_executor_job(
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     self._get_component, True
     ^^^^^^^^^^^^^^^^^^^^^^^^^
   )
   ^
  File “/usr/local/lib/python3.13/concurrent/futures/thread.py”, line 59, in run
   result = self.fn(*self.args, **self.kwargs)
  File “/usr/src/homeassistant/homeassistant/loader.py”, line 1077, in _get_component
   raise ImportError(f”Exception importing {self.pkg_path}“) from err
 ImportError: Exception importing custom_components.loxone

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File “/usr/src/homeassistant/homeassistant/loader.py”, line 1066, in _get_component
   ComponentProtocol, importlib.import_module(self.pkg_path)
             ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File “/usr/src/homeassistant/homeassistant/util/loop.py”, line 201, in protected_loop_func
   return func(*args, **kwargs)
  File “/usr/local/lib/python3.13/importlib/__init__.py”, line 88, in import_module
   return _bootstrap._gcd_import(name[level:], package, level)
       ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File “<frozen importlib._bootstrap>“, line 1387, in _gcd_import
  File “<frozen importlib._bootstrap>“, line 1360, in _find_and_load
  File “<frozen importlib._bootstrap>“, line 1331, in _find_and_load_unlocked
  File “<frozen importlib._bootstrap>“, line 935, in _load_unlocked
  File “<frozen importlib._bootstrap_external>“, line 1026, in exec_module
  File “<frozen importlib._bootstrap>“, line 488, in _call_with_frames_removed
  File “/config/custom_components/loxone/__init__.py”, line 38, in <module>
   from .coordinator import LoxoneCoordinator
  File “/config/custom_components/loxone/coordinator.py”, line 11, in <module>
   from .pyloxone_api.connection import LoxoneConnection, LoxoneException
  File “/config/custom_components/loxone/pyloxone_api/connection.py”, line 649
   except LoxoneConnectionError, LoxoneTokenError, LoxoneConnectionClosedOk:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 SyntaxError: multiple exception types must be parenthesized

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File “/usr/src/homeassistant/homeassistant/setup.py”, line 343, in _async_setup_component
   component = await integration.async_get_component()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File “/usr/src/homeassistant/homeassistant/loader.py”, line 1026, in async_get_component
   self._component_future.result()
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File “/usr/src/homeassistant/homeassistant/loader.py”, line 1018, in async_get_component
   comp = self._get_component()
  File “/usr/src/homeassistant/homeassistant/loader.py”, line 1077, in _get_component
   raise ImportError(f”Exception importing {self.pkg_path}“) from err
 ImportError: Exception importing custom_components.loxone
```