### PR TITLE
Expose pushbutton state_value for edge-aware automations

### DIFF
--- a/custom_components/loxone/button.py
+++ b/custom_components/loxone/button.py
@@ -62,6 +62,8 @@ class LoxoneButton(LoxoneEntity, ButtonEntity):
         super().__init__(**kwargs)
         self._attr_icon = None
         self._attr_unique_id = self.uuidAction
+        self._attr_state = None
+        self._state_value = None
 
     @property
     def icon(self):
@@ -88,6 +90,8 @@ class LoxoneButton(LoxoneEntity, ButtonEntity):
                 active = event.data[self.states["active"]]
                 new_state = True if active == 1.0 else False
                 if new_state != self._attr_state:
+                    self._attr_state = new_state
+                    self._state_value = active
                     self.__set_state(dt_util.utcnow().isoformat())
                     request_update = True
         if request_update:
@@ -109,6 +113,8 @@ class LoxoneButton(LoxoneEntity, ButtonEntity):
         return {
             **self._attr_extra_state_attributes,
             "state_uuid": self.states["active"],
+            "new_state": self._attr_state,
+            "state_value": self._state_value,
             "device_type": self.type,
         }
 


### PR DESCRIPTION
I am conscious of the limitation of pushbuttons in the readme - I am not sure what the issue is. Please chip in... I tried implementing this and so far so good...

I should modify the readme if this will be considered working.


## Summary
- expose new_state and state_value attributes for Loxone Pushbutton entities
- keep existing behavior, but make state_changed events edge-aware
- this allows users to distinguish press/release transitions directly from state attributes

## Why
Pushbutton entities currently emit updates on both edges, but there was no clear attribute in state_changed to identify transition direction.

## Example: trigger only on rising edge (common pattern)
```yaml
- condition: template
  value_template: >
    {{
      trigger.from_state.attributes.state_value | int(-1) == 0
      and trigger.to_state.attributes.state_value | int(-1) == 1
    }}
```

## Testing
- deployed locally and testing in real life
