### PR TITLE
Remove redundant 'loxone' prefix from device names

### DIFF
--- a/custom_components/loxone/helpers.py
+++ b/custom_components/loxone/helpers.py
@@ -17,7 +17,7 @@ def get_or_create_device(device_uuid, device_name, device_type, device_room):
     if device_uuid not in device_registry:
         device_registry[device_uuid] = {
             "identifiers": {(DOMAIN, device_uuid)},
-            "name": f"{DOMAIN} {device_name}",
+            "name": device_name,
             "manufacturer": "Loxone",
             "model": device_type,
             "suggested_area": device_room,


### PR DESCRIPTION
## Question / Discussion

I noticed that all Loxone devices in HA get a "loxone" prefix in their display name (e.g., "loxone Kitchen Light" instead of just "Kitchen Light"). This comes from `helpers.py:get_or_create_device()`:

```python
"name": f"{DOMAIN} {device_name}",
```

Is there a specific reason for this? The manufacturer field is already set to "Loxone", and HA shows the integration attribution in the UI, so the prefix seems redundant and adds noise to the device list.

This PR removes the prefix. When I tested locally, all active devices got renamed automatically on next HA load — no manual intervention needed, no broken automations (entity_ids are unaffected since they come from the entity's own name, not the device name).

## Changes

One-line change: device name uses `device_name` directly instead of `f"{DOMAIN} {device_name}"`.

## Observations from testing

- All existing devices got their display names updated immediately (HA updates device registry names, unlike entity_ids which are locked)
- Entity IDs unchanged
- Manufacturer still shows "Loxone" in device info

🤖 Generated with [Claude Code](https://claude.com/claude-code)