### PR TITLE
Always register LightControllerV2 subcontrols, use config to control enabled state

### DIFF
--- a/custom_components/loxone/light.py
+++ b/custom_components/loxone/light.py
@@ -76,7 +76,7 @@ async def async_setup_entry(
         new_light_controller = LoxoneLightControllerV2(**light_controller)
         entities.append(new_light_controller)
 
-        if generate_subcontrols and "subControls" in light_controller:
+        if "subControls" in light_controller:
             for sub_control_uuid in light_controller["subControls"]:
                 if (
                     sub_control_uuid.find("masterValue") > -1
@@ -91,6 +91,7 @@ async def async_setup_entry(
                         "lightcontroller_id": light_controller.get("uuidAction", None),
                         "lightcontroller_name": light_controller.get("name", None),
                         "async_add_devices": async_add_entities,
+                        "enabled_default": generate_subcontrols,
                     }
                 )
 

--- a/custom_components/loxone/lights/colorpickers.py
+++ b/custom_components/loxone/lights/colorpickers.py
@@ -38,6 +38,7 @@ class TunableWhiteLight(LoxoneEntity, LightEntity):
 
         if self._light_controller_id:
             self.type = "LightControllerV2"
+            self._attr_entity_registry_enabled_default = kwargs.get("enabled_default", True)
             self._attr_device_info = get_or_create_device(
                 self._light_controller_id, self.name, self.type, self.room
             )
@@ -140,6 +141,7 @@ class RGBColorPicker(LoxoneEntity, LightEntity):
 
         if self._light_controller_id:
             self.type = "LightControllerV2"
+            self._attr_entity_registry_enabled_default = kwargs.get("enabled_default", True)
             self._attr_device_info = get_or_create_device(
                 self._light_controller_id, self.name, self.type, self.room
             )
@@ -259,6 +261,7 @@ class LumiTech(RGBColorPicker):
         """Initialize the LumiTech."""
         if self._light_controller_id:
             self.type = "LightControllerV2"
+            self._attr_entity_registry_enabled_default = kwargs.get("enabled_default", True)
             self._attr_device_info = get_or_create_device(
                 self._light_controller_id, self.name, self.type, self.room
             )

--- a/custom_components/loxone/lights/dimmer.py
+++ b/custom_components/loxone/lights/dimmer.py
@@ -40,6 +40,7 @@ class LoxoneDimmer(LoxoneEntity, LightEntity):
 
         if self._light_controller_id:
             self.type = "LightControllerV2"
+            self._attr_entity_registry_enabled_default = kwargs.get("enabled_default", True)
             self._attr_device_info = get_or_create_device(
                 self._light_controller_id, self.name, self.type, self.room
             )
@@ -125,6 +126,7 @@ class EIBDimmer(LoxoneDimmer):
         super().__init__(**kwargs)
         if self._light_controller_id:
             self.type = "LightControllerV2"
+            self._attr_entity_registry_enabled_default = kwargs.get("enabled_default", True)
             self._attr_device_info = get_or_create_device(
                 self._light_controller_id, self.name, self.type, self.room
             )

--- a/custom_components/loxone/lights/switch.py
+++ b/custom_components/loxone/lights/switch.py
@@ -30,6 +30,7 @@ class LoxoneLightSwitch(LoxoneEntity, LightEntity):
 
         if self._light_controller_id:
             self.type = "LightControllerV2"
+            self._attr_entity_registry_enabled_default = kwargs.get("enabled_default", True)
             self._attr_device_info = get_or_create_device(
                 self._light_controller_id, self.name, self.type, self.room
             )

--- a/custom_components/loxone/translations/de.json
+++ b/custom_components/loxone/translations/de.json
@@ -13,7 +13,7 @@
           "host": "Miniserver Ip",
           "password": "Password",
           "generate_scenes": "Scenen generieren",
-          "generate_lightcontroller_subcontrols": "Subcontrols für LightcontrollerV2 erzeugen",
+          "generate_lightcontroller_subcontrols": "LightControllerV2-Subcontrols standardmäßig aktivieren",
           "generate_scenes_delay": "Verzögerung beim erstellen der Scenen (wenn aktiviert)"
         }
       }
@@ -28,7 +28,7 @@
           "host": "Miniserver Ip",
           "password": "Password",
           "generate_scenes": "Scenen generieren",
-          "generate_lightcontroller_subcontrols": "Subcontrols für LightcontrollerV2 erzeugen",
+          "generate_lightcontroller_subcontrols": "LightControllerV2-Subcontrols standardmäßig aktivieren",
           "generate_scenes_delay": "Verzögerung beim erstellen der Scenen (wenn aktiviert)"
         },
         "description": "PyLoxone Einstellungen editieren:",

--- a/custom_components/loxone/translations/en.json
+++ b/custom_components/loxone/translations/en.json
@@ -13,7 +13,7 @@
           "host": "Miniserver Ip",
           "password": "Password",
           "generate_scenes": "generate scenes",
-          "generate_lightcontroller_subcontrols": "generate subcontrols for lightcontrollerV2",
+          "generate_lightcontroller_subcontrols": "Enable LightControllerV2 subcontrols by default",
           "generate_scenes_delay": "Delay for the scene generation if enabled"
         }
       }
@@ -28,7 +28,7 @@
           "host": "Miniserver Ip",
           "password": "Password",
           "generate_scenes": "Generate scenes",
-          "generate_lightcontroller_subcontrols": "Generate subcontrols for lightcontrollerV2",
+          "generate_lightcontroller_subcontrols": "Enable LightControllerV2 subcontrols by default",
           "generate_scenes_delay": "Delay for the scene generation if enabled"
         },
         "description": "PyLoxone edit settings:",


### PR DESCRIPTION
## Summary

- LightControllerV2 subcontrols (dimmers, switches, color pickers) are now always registered in the entity registry, making them discoverable in the HA UI regardless of the config option
- The existing `generate_lightcontroller_subcontrols` option now controls whether subcontrols are **enabled by default** (True) or **disabled by default** (False) — rather than whether they exist at all
- Follows the same pattern used by Reolink, Shelly, and other HA core integrations (`entity_registry_enabled_default`)

## Motivation

The previous all-or-nothing boolean meant users either got zero subcontrols (and didn't know they were available) or ALL of them at once (5-10+ entities per controller, cluttering the UI). This change gives users:

- **Discoverability** — subcontrols are visible in the entity registry even when disabled
- **Granularity** — users can enable individual subcontrols without getting all of them
- **Zero clutter by default** — new installations see only the main LightControllerV2 entity

## Backward compatibility

- `entity_registry_enabled_default` only applies at first registration — already-registered entities keep their current enabled/disabled state
- Users who had the option set to `True`: subcontrols remain enabled, no change in behavior
- Users who had the option set to `False` (default): subcontrols now appear in the registry as disabled — functionally identical (no active entities), but now discoverable

## Test plan

- [x] Clean install with default config (option=False): only main LightControllerV2 entities active, subcontrols visible but disabled in entity registry (16 enabled, 55 disabled)
- [x] Clean install with option=True: all subcontrols created and enabled (71 enabled, 0 disabled)
- [x] Existing user with option=True, changes to False: entities stay enabled (registry preserves state)
- [x] Enable a single disabled subcontrol from entity registry → verify it becomes active after reload
- [ ] Standalone dimmers (not part of a LightControllerV2) remain enabled by default — verified by code inspection only (no standalone dimmers in test Miniserver config)
- [x] No errors in HA logs after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)