### PR TITLE
fix(sensor): use lowercase lx for illuminance unit

### DIFF
--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -115,7 +115,7 @@ SENSOR_TYPES: tuple[LoxoneEntityDescription, ...] = (
     ),
     LoxoneEntityDescription(
         key="illuminance",
-        loxone_format_strings=(LIGHT_LUX, "Lx", "lux"),
+        loxone_format_strings=(LIGHT_LUX, "lx", "lux"),
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.ILLUMINANCE,
     ),


### PR DESCRIPTION
## Problem

Home Assistant logs warnings because PyLoxone creates illuminance sensors with native unit `Lx` (uppercase L). For `device_class: illuminance`, Home Assistant only accepts lowercase `lx`.

## Fix

Change `"Lx"` to `"lx"` in the illuminance sensor description.

Fixes #492