### PR TITLE
Fix multi-instance entity/device cross-wiring (#491)

### DIFF
--- a/custom_components/loxone/__init__.py
+++ b/custom_components/loxone/__init__.py
@@ -415,7 +415,7 @@ async def async_setup_entry(hass, config_entry):
 
     async def loxone_discovered(event):
         _LOGGER.info("Creating groups")
-        miniserver = get_miniserver_from_hass(hass)
+        miniserver = get_miniserver_from_hass(hass, config_entry)
         if miniserver.miniserver_type < 2 and "component" in event.data:
             if event.data["component"] == DOMAIN:
                 try:

--- a/custom_components/loxone/alarm_control_panel.py
+++ b/custom_components/loxone/alarm_control_panel.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import LoxoneEntity
-from .const import DOMAIN, EVENT, SECUREDSENDDOMAIN, SENDDOMAIN
+from .const import DOMAIN, SECUREDSENDDOMAIN, SENDDOMAIN
 from .helpers import (add_room_and_cat_to_value_values, get_all,
                       get_or_create_device)
 from .miniserver import get_miniserver_from_hass
@@ -53,14 +53,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Loxone Alarms."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
     for loxone_alarm in get_all(loxconfig, "Alarm"):
         loxone_alarm = add_room_and_cat_to_value_values(loxconfig, loxone_alarm)
         loxone_alarm.update({"code": None})
         new_alarm = LoxoneAlarm(**loxone_alarm)
-        hass.bus.async_listen(EVENT, new_alarm.event_handler)
         entities.append(new_alarm)
 
     async_add_entities(entities, True)

--- a/custom_components/loxone/binary_sensor.py
+++ b/custom_components/loxone/binary_sensor.py
@@ -61,7 +61,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/button.py
+++ b/custom_components/loxone/button.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/climate.py
+++ b/custom_components/loxone/climate.py
@@ -76,7 +76,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up LoxoneRoomControllerV2."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/cover.py
+++ b/custom_components/loxone/cover.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set Loxone covers."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/fan.py
+++ b/custom_components/loxone/fan.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/light.py
+++ b/custom_components/loxone/light.py
@@ -54,7 +54,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Loxone Light Controller."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     generate_subcontrols = config_entry.options.get(
         "generate_lightcontroller_subcontrols", False
     )

--- a/custom_components/loxone/media_player.py
+++ b/custom_components/loxone/media_player.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Load Loxone Audio zones based on a config entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/miniserver.py
+++ b/custom_components/loxone/miniserver.py
@@ -23,17 +23,9 @@ NEW_COVERS = "covers"
 
 
 @callback
-def get_miniserver_from_hass(hass):
-    """Return Miniserver with a matching bridge id."""
-    return hass.data[DOMAIN][list(hass.data[DOMAIN].keys())[0]].miniserver
-
-
-@callback
-def get_miniserver_from_config(hass, config):
-    """Return first Miniserver. Only one Miniserver is allowed"""
-    if len(config) == 0:
-        return None
-    return config[next(iter(config))]
+def get_miniserver_from_hass(hass, config_entry):
+    """Return the Miniserver for this specific config entry."""
+    return hass.data[DOMAIN][config_entry.entry_id].miniserver
 
 
 @dataclass

--- a/custom_components/loxone/number.py
+++ b/custom_components/loxone/number.py
@@ -39,7 +39,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/select.py
+++ b/custom_components/loxone/select.py
@@ -97,7 +97,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -201,7 +201,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
 
     loxconfig = miniserver.lox_config.json
     entities: list[Any] = [LoxoneKeepAliveSensor(miniserver.serial)]

--- a/custom_components/loxone/switch.py
+++ b/custom_components/loxone/switch.py
@@ -39,7 +39,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 

--- a/custom_components/loxone/text.py
+++ b/custom_components/loxone/text.py
@@ -39,7 +39,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry."""
-    miniserver = get_miniserver_from_hass(hass)
+    miniserver = get_miniserver_from_hass(hass, config_entry)
     loxconfig = miniserver.lox_config.json
     entities = []
 


### PR DESCRIPTION
## Summary

Follows up on #491. The 0.9.16 fix for that issue namespaced the
keep-alive/software-version sensor unique IDs by serial, which helps
those two specific entities, but the actual root cause was untouched
and still affects every other platform.

**Root cause:** `get_miniserver_from_hass(hass)` in `miniserver.py`
always returns the *first*-registered config entry's `MiniServer`:

```python
def get_miniserver_from_hass(hass):
    return hass.data[DOMAIN][list(hass.data[DOMAIN].keys())[0]].miniserver
```

Every platform's `async_setup_entry(hass, config_entry, async_add_entities)`
calls this instead of using the `config_entry` it was actually invoked
for. With two or more Miniservers configured, the second (and any
subsequent) instance's platforms build entities from the *first*
instance's structure file, producing duplicate `uuidAction`/unique_id
entities that collide with the first instance's already-registered
entities ("Platform loxone does not generate unique IDs" errors) and
causing previously-working entities to go unavailable.

Separately, `alarm_control_panel.py` has its own bug: it subscribes to
the event bus directly in `async_setup_entry`, before `async_add_entities`
has decided whether the entity is actually accepted:

```python
new_alarm = LoxoneAlarm(**loxone_alarm)
hass.bus.async_listen(EVENT, new_alarm.event_handler)   # fires unconditionally
entities.append(new_alarm)
async_add_entities(entities, True)                      # may reject duplicates
```

If HA rejects the entity for a duplicate unique_id (which happens today
because of the bug above), the listener is never unsubscribed and keeps
calling `self.async_schedule_update_ha_state()` on an entity whose
`.hass` was never set, producing a repeating
`RuntimeError: Attribute hass is None` on every subsequent websocket
event.

## Changes

- `miniserver.py`: scope `get_miniserver_from_hass()` by
  `config_entry.entry_id` instead of always returning the
  first-registered instance; drop the dead, single-instance-only
  `get_miniserver_from_config()`.
- Thread `config_entry` through to the lookup in all 12 platform files
  (`climate`, `switch`, `cover`, `sensor`, `binary_sensor`, `light`,
  `alarm_control_panel`, `button`, `fan`, `media_player`, `number`,
  `text`) and `__init__.py`'s `loxone_discovered()`.
- `alarm_control_panel.py`: remove the premature `hass.bus.async_listen`
  call; `LoxoneAlarm` already inherits `LoxoneEntity`'s standard
  `async_added_to_hass`/`async_will_remove_from_hass` lifecycle, which
  now handles subscription correctly like every other platform.

## Test plan

- [x] Verified against two real Miniservers (different physical
      buildings) running concurrently for several days.
- [x] No more "Platform loxone does not generate unique IDs" errors on
      startup with both instances configured.
- [x] No more repeating `RuntimeError: Attribute hass is None` from
      the alarm platform.
- [x] Both instances' entities (climate, switch, cover, light, sensor,
      alarm, etc.) stay available after both integrations finish
      loading, regardless of setup order.
- [x] Confirmed via Home Assistant's device registry that devices are
      no longer cross-associated with the wrong config entry after
      the fix (previously, two lighting-controller devices had leaked
      an extra `config_entries` association from before the fix was
      applied; this is a one-time artifact of the old bug, not
      something the fix needs to clean up itself).