### PR TITLE
Use supported config entry migration API

### DIFF
--- a/custom_components/loxone/__init__.py
+++ b/custom_components/loxone/__init__.py
@@ -147,18 +147,25 @@ async def async_setup(hass, config):
 
 
 async def async_migrate_entry(hass, config_entry):
-    # _LOGGER.debug("Migrating from version %s", config_entry.version)
-    if config_entry.version == 1:
-        new = {**config_entry.options, CONF_LIGHTCONTROLLER_SUBCONTROLS_GEN: True}
-        config_entry.options = {**new}
-        config_entry.version = 2
+    """Migrate a config entry using Home Assistant's supported update API."""
+    old_version = config_entry.version
+    version = old_version
+    options = dict(config_entry.options)
+
+    if version == 1:
+        options[CONF_LIGHTCONTROLLER_SUBCONTROLS_GEN] = True
+        version = 2
         _LOGGER.info("Migration to version %s successful", 2)
 
-    if config_entry.version == 2:
-        new = {**config_entry.options, CONF_SCENE_GEN_DELAY: DEFAULT_DELAY_SCENE}
-        config_entry.options = {**new}
-        config_entry.version = 3
+    if version == 2:
+        options[CONF_SCENE_GEN_DELAY] = DEFAULT_DELAY_SCENE
+        version = 3
         _LOGGER.info("Migration to version %s successful", 3)
+
+    if version != old_version:
+        hass.config_entries.async_update_entry(
+            config_entry, options=options, version=version
+        )
     return True
 
 

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -1,0 +1,46 @@
+"""Tests for Loxone config entry migrations."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from custom_components.loxone import async_migrate_entry
+from custom_components.loxone.const import (
+    CONF_LIGHTCONTROLLER_SUBCONTROLS_GEN,
+    CONF_SCENE_GEN_DELAY,
+    DEFAULT_DELAY_SCENE,
+)
+
+
+class _ConfigEntries:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def async_update_entry(self, entry, **changes) -> None:
+        self.calls.append(changes)
+        for key, value in changes.items():
+            setattr(entry, key, value)
+
+
+def test_version_one_migrates_through_all_versions_in_one_update() -> None:
+    config_entries = _ConfigEntries()
+    hass = SimpleNamespace(config_entries=config_entries)
+    entry = SimpleNamespace(version=1, options={})
+
+    assert asyncio.run(async_migrate_entry(hass, entry)) is True
+
+    assert entry.version == 3
+    assert entry.options[CONF_LIGHTCONTROLLER_SUBCONTROLS_GEN] is True
+    assert entry.options[CONF_SCENE_GEN_DELAY] == DEFAULT_DELAY_SCENE
+    assert len(config_entries.calls) == 1
+
+
+def test_current_version_does_not_update_entry() -> None:
+    config_entries = _ConfigEntries()
+    hass = SimpleNamespace(config_entries=config_entries)
+    entry = SimpleNamespace(version=3, options={})
+
+    assert asyncio.run(async_migrate_entry(hass, entry)) is True
+
+    assert config_entries.calls == []


### PR DESCRIPTION
## Problem

Current Home Assistant versions reject direct assignments to `config_entry.options` and `config_entry.version`. Existing Loxone migrations therefore fail with `AttributeError` and leave the entry in `migration_error`.

## Fix

Collect all migration changes locally and apply them once through Home Assistant's supported `async_update_entry` API. The existing config versions and migration results remain unchanged.

## Tested with

- Home Assistant 2026.7.2
- Loxone Miniserver 17.1.6.30
- Linux, Python 3.14: `2 passed`
- Migration failure reproduced on the live installation; the supported update path completed successfully
