### PR TITLE
Accept Loxone Lx illuminance unit

### DIFF
--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -115,7 +115,7 @@ SENSOR_TYPES: tuple[LoxoneEntityDescription, ...] = (
     ),
     LoxoneEntityDescription(
         key="illuminance",
-        loxone_format_strings=(LIGHT_LUX, "lx", "lux"),
+        loxone_format_strings=(LIGHT_LUX, "Lx", "lx", "lux"),
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.ILLUMINANCE,
     ),


### PR DESCRIPTION
## Problem

Loxone Miniserver 17.1.6.30 reports illuminance with the unit spelling `Lx`. Matching is case-sensitive and currently accepts only `lx` and `lux`, so these values are not classified as illuminance sensors.

## Fix

Accept `Lx` as an additional Loxone input spelling. Home Assistant continues to represent the value as standard illuminance.

## Tested with

- Home Assistant 2026.7.2
- Loxone Miniserver 17.1.6.30
- Linux, Python 3.14: `50 passed`
