### PR TITLE
Fix: encode Basic Auth credentials as UTF-8 to support non-ASCII usernames

### DIFF
--- a/custom_components/loxone/pyloxone_api/loxone_http_client.py
+++ b/custom_components/loxone/pyloxone_api/loxone_http_client.py
@@ -78,7 +78,7 @@ class LoxoneAsyncHttpClient:
         try:
             _LOGGER.debug(f"Making GET request to: {url}")
             request_kwargs = {
-                "auth": aiohttp.BasicAuth(self.username, self.password),
+                "auth": aiohttp.BasicAuth(self.username, self.password, encoding="utf-8"),
                 "timeout": aiohttp.ClientTimeout(total=self.timeout),
             }
             if self.scheme == "https":


### PR DESCRIPTION
## Summary
aiohttp.BasicAuth defaults to latin-1 encoding, but the Loxone Miniserver expects UTF-8 for Basic Auth credentials. This causes 401 Unauthorized errors for usernames with non-ASCII characters. Adding encoding='utf-8' resolves the mismatch.

**Fixes:** https://github.com/JoDehli/PyLoxone/issues/506

---

### Changes Made
- `custom_components/loxone/pyloxone_api/loxone_http_client.py`
