### PR TITLE
Restore config entry version 4 migration

### DIFF
--- a/custom_components/loxone/__init__.py
+++ b/custom_components/loxone/__init__.py
@@ -151,18 +151,30 @@ async def async_setup(hass, config):
 
 
 async def async_migrate_entry(hass, config_entry):
-    # _LOGGER.debug("Migrating from version %s", config_entry.version)
-    if config_entry.version == 1:
-        new = {**config_entry.options, CONF_LIGHTCONTROLLER_SUBCONTROLS_GEN: True}
-        config_entry.options = {**new}
-        config_entry.version = 2
+    """Migrate a config entry using Home Assistant's supported update API."""
+    old_version = config_entry.version
+    version = old_version
+    options = dict(config_entry.options)
+
+    if version == 1:
+        options[CONF_LIGHTCONTROLLER_SUBCONTROLS_GEN] = True
+        version = 2
         _LOGGER.info("Migration to version %s successful", 2)
 
-    if config_entry.version == 2:
-        new = {**config_entry.options, CONF_SCENE_GEN_DELAY: DEFAULT_DELAY_SCENE}
-        config_entry.options = {**new}
-        config_entry.version = 3
+    if version == 2:
+        options[CONF_SCENE_GEN_DELAY] = DEFAULT_DELAY_SCENE
+        version = 3
         _LOGGER.info("Migration to version %s successful", 3)
+
+    if version == 3:
+        options[CONF_VERIFY_SSL] = DEFAULT_VERIFY_SSL
+        version = 4
+        _LOGGER.info("Migration to version %s successful", 4)
+
+    if version != old_version:
+        hass.config_entries.async_update_entry(
+            config_entry, options=options, version=version
+        )
     return True
 
 

--- a/custom_components/loxone/config_flow.py
+++ b/custom_components/loxone/config_flow.py
@@ -123,7 +123,7 @@ OPTIONS_FLOW = {
 class LoxoneFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle Loxone config flow."""
 
-    VERSION = 3
+    VERSION = 4
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW
 

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -9,7 +9,9 @@ from custom_components.loxone import async_migrate_entry
 from custom_components.loxone.const import (
     CONF_LIGHTCONTROLLER_SUBCONTROLS_GEN,
     CONF_SCENE_GEN_DELAY,
+    CONF_VERIFY_SSL,
     DEFAULT_DELAY_SCENE,
+    DEFAULT_VERIFY_SSL,
 )
 
 
@@ -23,6 +25,18 @@ class _ConfigEntries:
             setattr(entry, key, value)
 
 
+def test_version_three_migration_uses_home_assistant_update_api() -> None:
+    config_entries = _ConfigEntries()
+    hass = SimpleNamespace(config_entries=config_entries)
+    entry = SimpleNamespace(version=3, options={"host": "192.0.2.1"})
+
+    assert asyncio.run(async_migrate_entry(hass, entry)) is True
+
+    assert entry.version == 4
+    assert entry.options[CONF_VERIFY_SSL] is DEFAULT_VERIFY_SSL
+    assert len(config_entries.calls) == 1
+
+
 def test_version_one_migrates_through_all_versions_in_one_update() -> None:
     config_entries = _ConfigEntries()
     hass = SimpleNamespace(config_entries=config_entries)
@@ -30,16 +44,17 @@ def test_version_one_migrates_through_all_versions_in_one_update() -> None:
 
     assert asyncio.run(async_migrate_entry(hass, entry)) is True
 
-    assert entry.version == 3
+    assert entry.version == 4
     assert entry.options[CONF_LIGHTCONTROLLER_SUBCONTROLS_GEN] is True
     assert entry.options[CONF_SCENE_GEN_DELAY] == DEFAULT_DELAY_SCENE
+    assert entry.options[CONF_VERIFY_SSL] is DEFAULT_VERIFY_SSL
     assert len(config_entries.calls) == 1
 
 
 def test_current_version_does_not_update_entry() -> None:
     config_entries = _ConfigEntries()
     hass = SimpleNamespace(config_entries=config_entries)
-    entry = SimpleNamespace(version=3, options={})
+    entry = SimpleNamespace(version=4, options={})
 
     assert asyncio.run(async_migrate_entry(hass, entry)) is True
 


### PR DESCRIPTION
## Problem

Release 0.9.20 includes the configurable TLS verification option, but
`LoxoneFlowHandler.VERSION` is still 3 and the migration only handles versions
1 through 3. Existing entries that were already migrated to version 4 therefore
fail to load:

`Config entry ... has version 4 which is higher than the current version 3`

## Fix

- Restore config entry version 4.
- Migrate version 3 entries by adding the `verify_ssl` default.
- Use Home Assistant's supported `async_update_entry` API for all migration
  steps.
- Extend the focused migration tests.

No unrelated integration behavior or manifest version is changed.

## Validation

- `python -m compileall -q custom_components/loxone`
- Focused structural migration validation
- Installed commit `1de8ec9` from HACS on Home Assistant 2026.7.4
- Tested against Loxone Miniserver 17.1.6.30
- Config entry changed from `migration_error` to `loaded`
- 57 entities and 36 devices registered
- No new PyLoxone or migration errors after restart

The full local pytest run was unavailable because the pinned Home Assistant
2026.6.4 test dependency requires Python 3.14.2 while the available local
interpreter is Python 3.13. CI can run the added focused tests in the project
environment.
