### PR TITLE
fix: replace deprecated CONCENTRATION_PARTS_PER_MILLION with UnitOfRatio.PARTS_PER_MILLION

### DIFF
--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -17,12 +17,11 @@ from homeassistant.components.sensor import (CONF_STATE_CLASS, PLATFORM_SCHEMA,
                                              SensorEntityDescription,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (CONCENTRATION_PARTS_PER_MILLION,
-                                 CONF_DEVICE_CLASS, CONF_NAME,
+from homeassistant.const import (CONF_DEVICE_CLASS, CONF_NAME,
                                  CONF_UNIT_OF_MEASUREMENT, CONF_VALUE_TEMPLATE,
                                  LIGHT_LUX, PERCENTAGE, STATE_UNKNOWN,
-                                 UnitOfEnergy, UnitOfPower, UnitOfSpeed,
-                                 UnitOfTemperature, UnitOfVolume,
+                                 UnitOfEnergy, UnitOfPower, UnitOfRatio,
+                                 UnitOfSpeed, UnitOfTemperature, UnitOfVolume,
                                  UnitOfVolumeFlowRate)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -121,7 +120,7 @@ SENSOR_TYPES: tuple[LoxoneEntityDescription, ...] = (
     ),
     LoxoneEntityDescription(
         key="carbon_dioxide",
-        loxone_format_strings=(CONCENTRATION_PARTS_PER_MILLION,),
+        loxone_format_strings=(UnitOfRatio.PARTS_PER_MILLION,),
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CO2,
     ),

--- a/tests/test_sensor_matching.py
+++ b/tests/test_sensor_matching.py
@@ -3,11 +3,11 @@ import pytest
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
     PERCENTAGE,
     UnitOfEnergy,
     UnitOfPower,
+    UnitOfRatio,
     UnitOfSpeed,
     UnitOfTemperature,
     UnitOfVolume,
@@ -63,7 +63,7 @@ class TestSensorMatching:
         assert desc.device_class == SensorDeviceClass.ILLUMINANCE
 
     def test_carbon_dioxide_ppm(self):
-        desc = match_sensor_description(unit=CONCENTRATION_PARTS_PER_MILLION)
+        desc = match_sensor_description(unit=UnitOfRatio.PARTS_PER_MILLION)
         assert desc is not None
         assert desc.device_class == SensorDeviceClass.CO2
 
@@ -186,7 +186,7 @@ class TestUnambiguousUnits:
         assert UnitOfTemperature.CELSIUS in UNAMBIGUOUS_UNITS
 
     def test_ppm_is_unambiguous(self):
-        assert CONCENTRATION_PARTS_PER_MILLION in UNAMBIGUOUS_UNITS
+        assert UnitOfRatio.PARTS_PER_MILLION in UNAMBIGUOUS_UNITS
 
     def test_percentage_is_not_unambiguous(self):
         """% is ambiguous (could be humidity or battery)."""
@@ -240,7 +240,7 @@ class TestUnitExtraction:
         assert clean_unit("%.0f Lx") == "Lx"
 
     def test_extract_ppm(self):
-        assert clean_unit("%.0f ppm") == CONCENTRATION_PARTS_PER_MILLION
+        assert clean_unit("%.0f ppm") == UnitOfRatio.PARTS_PER_MILLION
 
     def test_extract_bare_format(self):
         """Format string without a unit returns the cleaned string."""


### PR DESCRIPTION
## Summary

Addresses the HA Core deprecation warning:

> The deprecated constant `CONCENTRATION_PARTS_PER_MILLION` was used from loxone. It will be removed in HA Core 2027.8. Use `UnitOfRatio.PARTS_PER_MILLION` instead.

## Changes

- **`custom_components/loxone/sensor.py`**: Removed `CONCENTRATION_PARTS_PER_MILLION` import, added `UnitOfRatio` and updated the CO2 sensor description to use `UnitOfRatio.PARTS_PER_MILLION`.
- **`tests/test_sensor_matching.py`**: Replaced all occurrences of `CONCENTRATION_PARTS_PER_MILLION` with `UnitOfRatio.PARTS_PER_MILLION`.