### PR TITLE
Fix ventilation fan entity registration when presence is enabled

### DIFF
--- a/custom_components/loxone/binary_sensor.py
+++ b/custom_components/loxone/binary_sensor.py
@@ -134,16 +134,15 @@ class LoxoneDigitalSensor(LoxoneEntity, BinarySensorEntity):
         else:
             self._attr_device_class = None
 
-        if self._parent_id:
-            self.uuidAction = self._parent_id
+        device_uuid = self._parent_id or self.unique_id
 
         if self._from_loxone_config:
             self._attr_device_info = get_or_create_device(
-                self.unique_id, self.name, self.type, self.room
+                device_uuid, self.name, self.type, self.room
             )
         else:
             self._attr_device_info = get_or_create_device(
-                self.unique_id, self.name, self.type, ""
+                device_uuid, self.name, self.type, ""
             )
 
         if self._from_loxone_config:


### PR DESCRIPTION
The presence sensor previously replaced its own UUID with the parent ventilation UUID, causing a unique-ID collision with the corresponding fan entity. This change preserves the presence sensor’s UUID and uses the parent UUID only for device grouping.