### PR TITLE
add message center sensor and issue creation

### DIFF
--- a/custom_components/loxone/__init__.py
+++ b/custom_components/loxone/__init__.py
@@ -38,9 +38,7 @@ from .const import (ATTR_AREA_CREATE, ATTR_CODE, ATTR_COMMAND, ATTR_DEVICE,
                     DOMAIN, DOMAIN_DEVICES, ERROR_VALUE, EVENT, LOXONE_PLATFORMS,
                     SECUREDSENDDOMAIN, SENDDOMAIN, cfmt)
 from .coordinator import LoxoneCoordinator
-from .helpers import get_miniserver_type
-from .miniserver import MiniServer, get_miniserver_from_hass
-from .pyloxone_api.connection import LoxoneConnection
+from .miniserver import get_miniserver_from_hass
 from .pyloxone_api.exceptions import (LoxoneConnectionClosedOk,
                                       LoxoneConnectionError, LoxoneException,
                                       LoxoneOutOfServiceException,

--- a/custom_components/loxone/helpers.py
+++ b/custom_components/loxone/helpers.py
@@ -5,13 +5,17 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/loxone/
 """
 
+import datetime
 import re
 
 from .const import DOMAIN, cfmt
+from homeassistant.util import dt as dt_util
 
 # Initialize a device registry
 device_registry = {}
 
+def get_device(device_uuid, default = None):
+    return device_registry.get(device_uuid, default)
 
 def get_or_create_device(device_uuid, device_name, device_type, device_room):
     if device_uuid not in device_registry:
@@ -144,3 +148,10 @@ def clean_unit(lox_format):
             unit = "%"
         return unit
     return lox_format
+
+LOXONE_EPOCH = dt_util.parse_datetime("2009-01-01T00:00:00.000")
+
+def get_datetime_from_loxone(timestamp: float):
+    timestamp /= 1000
+    timestamp += LOXONE_EPOCH.timestamp()
+    return dt_util.utc_from_timestamp(timestamp)

--- a/custom_components/loxone/miniserver.py
+++ b/custom_components/loxone/miniserver.py
@@ -13,7 +13,6 @@ from homeassistant.helpers import device_registry as dr
 from .helpers import get_miniserver_type
 
 _LOGGER = logging.getLogger(__name__)
-CONNECTION_NETWORK_MAC = "mac"
 DOMAIN = "loxone"
 NEW_GROUP = "groups"
 NEW_LIGHT = "lights"
@@ -23,7 +22,7 @@ NEW_COVERS = "covers"
 
 
 @callback
-def get_miniserver_from_hass(hass, config_entry):
+def get_miniserver_from_hass(hass, config_entry) -> MiniServer:
     """Return the Miniserver for this specific config entry."""
     return hass.data[DOMAIN][config_entry.entry_id].miniserver
 
@@ -88,29 +87,33 @@ class MiniServer:
         }
         return new_device[device_type]
 
-    async def async_update_device_registry(self) -> None:
-        device_registry = dr.async_get(self.hass)
-        # Host device
-        # device_registry.async_get_or_create(
-        #     config_entry_id=self.config_entry.entry_id,
-        #     connections={
-        #         (CONNECTION_NETWORK_MAC, self.config_entry.options[CONF_HOST])
-        #     },
-        # )
+    @property
+    def get_device(self) -> dr.DeviceEntry:
+        return self.device_entry
 
-        # Miniserver service
-        device_registry.async_get_or_create(
-            config_entry_id=self.config_entry.entry_id,
-            connections={
-                (CONNECTION_NETWORK_MAC, self.config_entry.options[CONF_HOST])
+    @property
+    def device_info(self) -> dr.DeviceInfo:
+        return {
+            "name": self.name,
+            "model": get_miniserver_type(self.miniserver_type),
+            "identifiers": {(DOMAIN, self.serial)},
+            "serial_number": self.serial,
+            "manufacturer": "Loxone",
+            "connections":{
+                (dr.CONNECTION_NETWORK_MAC, self.config_entry.options[CONF_HOST])
             },
-            name=self.name,
-            model=get_miniserver_type(self.miniserver_type),
-            identifiers={(DOMAIN, self.serial)},
-            manufacturer="Loxone",
-            sw_version=self.software_version,
-            configuration_url="http://{host}:{port}".format(
+            "sw_version": self.software_version,
+            "configuration_url":"http://{host}:{port}".format(
                 host=self.config_entry.options[CONF_HOST],
                 port=self.config_entry.options[CONF_PORT],
             ),
+        }
+
+    async def async_update_device_registry(self) -> None:
+        device_registry = dr.async_get(self.hass)
+
+        # Miniserver service
+        self.device_entry = device_registry.async_get_or_create(
+            config_entry_id=self.config_entry.entry_id,
+            **self.device_info,
         )

--- a/custom_components/loxone/sensor.py
+++ b/custom_components/loxone/sensor.py
@@ -23,19 +23,20 @@ from homeassistant.const import (CONF_DEVICE_CLASS, CONF_NAME,
                                  LIGHT_LUX, PERCENTAGE, STATE_UNKNOWN,
                                  UnitOfEnergy, UnitOfPower, UnitOfRatio,
                                  UnitOfSpeed, UnitOfTemperature, UnitOfVolume,
-                                 UnitOfVolumeFlowRate)
+                                 UnitOfVolumeFlowRate, EntityCategory)
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from . import LoxoneEntity, MiniServer
 from .const import CLIMATE_EVENT, CONF_ACTIONID, DOMAIN, EVENT, SENDDOMAIN, THROTTLE_KEEP_ALIVE_TIME
-from .helpers import (add_room_and_cat_to_value_values, clean_unit, get_all,
+from .helpers import (add_room_and_cat_to_value_values, clean_unit, get_all, get_datetime_from_loxone, get_device,
                       get_or_create_device)
 from .miniserver import get_miniserver_from_hass
+from custom_components.loxone import LoxoneEntity, miniserver
 
 NEW_SENSOR = "sensors"
 
@@ -215,10 +216,14 @@ async def async_setup_entry(
     miniserver = get_miniserver_from_hass(hass, config_entry)
 
     loxconfig = miniserver.lox_config.json
-    entities: list[Any] = [LoxoneKeepAliveSensor(miniserver.serial)]
+    if loxconfig is None:
+        _LOGGER.error("No config json found")
+        return
+
+    entities: list[Any] = [LoxoneKeepAliveSensor(miniserver.serial, miniserver)]
 
     if "softwareVersion" in loxconfig:
-        entities.append(LoxoneVersionSensor(miniserver.serial, loxconfig["softwareVersion"]))
+        entities.append(LoxoneVersionSensor(miniserver.serial, loxconfig["softwareVersion"], miniserver))
 
     for sensor in get_all(loxconfig, "InfoOnlyAnalog"):
         sensor = add_room_and_cat_to_value_values(loxconfig, sensor)
@@ -294,6 +299,15 @@ async def async_setup_entry(
                 parent_uuid=irc["uuidAction"],
             ))
 
+    if "globalStates" in loxconfig:
+        global_states = loxconfig.get("globalStates")
+        entities.append(LoxoneNotificationsSensor(miniserver.serial, global_states.get("notifications", None), miniserver))
+
+    messageCenter = loxconfig.get("messageCenter", {})
+    for key in messageCenter.keys():
+        sensor = messageCenter.get(key)
+        entities.append(LoxoneMessageCenterSensor(miniserver, **sensor))
+
     @callback
     def async_add_sensors(_):
         async_add_entities(_, True)
@@ -351,12 +365,14 @@ class LoxoneKeepAliveSensor(LoxoneEntity, SensorEntity):
     _attr_name = "Loxone Last Keep Alive Message"
     _attr_icon = "mdi:information-outline"
     _attr_unique_id = "loxone_keep_alive_sensor_uuid"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.TIMESTAMP  # tell HA this is a timestamp
 
-    def __init__(self, miniserver_serial, **kwargs):
+    def __init__(self, miniserver_serial, miniserver: miniserver.MiniServer, **kwargs):
         super().__init__(**kwargs)
         self._miniserver_serial = miniserver_serial
         self._attr_native_value = None
+        self._attr_device_info = miniserver.device_info
 
     @cached_property
     def unique_id(self) -> str:
@@ -388,9 +404,11 @@ class LoxoneVersionSensor(LoxoneEntity, SensorEntity):
     _attr_name = "Loxone Software Version"
     _attr_icon = "mdi:information-outline"
     _attr_unique_id = "loxone_software_version_uuid"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, minisersver_serial, version_list, **kwargs):
+    def __init__(self, minisersver_serial, version_list, miniserver: miniserver.MiniServer, **kwargs):
         super().__init__(**kwargs)
+        self._attr_device_info = miniserver.device_info
         self._miniserver_serial = minisersver_serial
         try:
             self._attr_native_value = ".".join([str(x) for x in version_list])
@@ -664,3 +682,185 @@ class LoxoneClimateController(LoxoneEntity, SensorEntity):
             "cool_demand": self._cool_demand,
             "device_type": self.type,
         }
+
+class LoxoneNotificationsSensor(LoxoneEntity, SensorEntity):
+    _attr_should_poll = False
+    _attr_name = "Loxone Notificaitons"
+    _attr_icon = "mdi:information-outline"
+    _attr_unique_id = "loxone_notifications"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, minisersver_serial, notifications_uuid, miniserver: miniserver.MiniServer, **kwargs):
+        super().__init__(**kwargs)
+        self._attr_device_info = miniserver.device_info
+        self._miniserver_serial = minisersver_serial
+        self.uuidAction = notifications_uuid
+        self._state = STATE_UNKNOWN
+
+    @cached_property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"{self._miniserver_serial}-{self._attr_unique_id}"
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    async def event_handler(self, e):
+        if self.uuidAction in e.data:
+            self._state = e.data[self.uuidAction]
+            _LOGGER.info(f"notification {e.data[self.uuidAction]}")
+            self.async_schedule_update_ha_state()
+
+class LoxoneMessageCenterSensor(LoxoneEntity, SensorEntity):
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, miniserver: miniserver.MiniServer, **kwargs):
+        self._attr_state_class = kwargs.pop("state_class", None)
+        self._attr_device_class = kwargs.pop("device_class", None)
+        self._attr_name = kwargs.pop("name", None)
+        self._attr_native_value = None  # Initialize state
+        # Must be after the kwargs.pop functions!
+        super().__init__(**kwargs)
+        self._attr_device_info = miniserver.device_info
+        self._last_update = None
+        self._changed_uuid = self.states.get("changed")
+        self._status = {}
+
+    @cached_property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self.uuidAction
+
+    async def event_handler(self, e):
+        if self.uuidAction in e.data:
+            data = e.data[self.uuidAction]
+            self._active_entries = data
+
+            self.async_schedule_update_ha_state()
+        if self._changed_uuid in e.data:
+            changed = get_datetime_from_loxone(e.data[self._changed_uuid])
+            if self._last_update is None or changed > self._last_update:
+                self.hass.async_create_task(
+                    self.update_entries(),
+                    f"Update message center entries {self.entity_id}"
+                )
+        control = e.data.get("control", None)
+        if control and self.uuidAction in control and "getEntries" in control:
+            self.hass.async_create_task(
+                self.process_entries(e.data.get("value")),
+                f"Process message center entries {self.entity_id}"
+            )
+
+    @property
+    def extra_state_attributes(self):
+        """Return device specific state attributes."""
+        return {
+            **self._attr_extra_state_attributes,
+            "status": self._status
+        }
+
+    async def update_entries(self):
+        await self.hass.services.async_call(DOMAIN, "event_websocket_command", {
+            "uuid": self.uuidAction,
+            "value": "getEntries/2"
+        })
+
+    async def process_entries(self, value):
+        max_severity = 0
+        status = {}
+        value = json.loads(value)
+        entries = value.get("entries")
+        self._last_update = dt_util.utcnow()
+        issue_ids = []
+        for entry in entries:
+            if entry.get("isHistoric", False):
+                await self.clear_history_entry(entry)
+            else:
+                severity = entry.get("severity", 0)
+                if severity not in status:
+                    status[severity] = 0
+                status[severity] += 1
+                if severity > max_severity:
+                    max_severity = severity
+                issue_ids.append(entry.get("entryUuid"))
+                await self.process_active_entry(entry)
+
+        self._status = status
+        self._attr_native_value = max_severity
+        self.schedule_update_ha_state()
+
+        cleared = set(id for domain, id in ir.async_get(self.hass).issues if domain == "loxone" and id not in issue_ids)
+        for id in cleared:
+            _LOGGER.warning(f"issue registry has id {id} which is no longer an issue and was never deleted removing")
+            ir.async_delete_issue(
+                self.hass,
+                DOMAIN,
+                id,
+            )
+
+    async def clear_history_entry(self, entry):
+        entry_id = entry.get("entryUuid")
+        ir.async_delete_issue(
+            self.hass,
+            DOMAIN,
+            entry_id,
+        )
+
+    async def process_active_entry(self, entry):
+        entry_id = entry.get("entryUuid")
+        affected_uuids = entry.get("affectedUuids", None)
+        source_uuid = entry.get("sourceUuid", None)
+        message = entry.get("desc")
+        message = message.replace("<br><br>Further details can be found under the following link.", "\n")
+        help_link = entry.get("helpLink", None)
+        title = entry.get("title")
+        event_id = entry.get("eventId")
+        name = entry.get("affectedName", "Unknown")
+        severity = entry.get("severity", 0)
+        severity_str = "Critical" if severity > 3 else "Error" if severity > 2 else "Warning" if severity > 1 else "Info"
+        timestamps = entry.get("timestamps")
+        timestamp = dt_util.utc_from_timestamp(timestamps[0])
+        message += f"\n\nOccured at: {timestamp}"
+        _LOGGER.info(f"Message Center Status {timestamp} {severity_str} {event_id} {title} {name}")
+        issue_severity = ir.IssueSeverity.WARNING
+        if severity > 3:
+            issue_severity = ir.IssueSeverity.CRITICAL
+        elif severity > 2:
+            issue_severity = ir.IssueSeverity.ERROR
+
+        entities = er.async_get(self.hass).entities.get_entries_for_config_entry_id(self.platform.config_entry.entry_id) if self.platform.config_entry else None
+        translation_placeholders = {
+            "name": name,
+            "message_name": name,
+            "title": title,
+            "description": message,
+        }
+        data = {
+            "entry": entry,
+            "devices": []
+        }
+        for affected in affected_uuids:
+            device = get_device(affected, {})
+            if device and entities:
+                data["devices"].append(device)
+                entity = next(filter(lambda c: c.unique_id == affected, entities), None)
+                if entity:
+                    device_name = entity.name if entity.name else entity.original_name
+                    translation_placeholders["entity_id"] = entity.entity_id
+                    translation_placeholders["description"] += f"\n[{device_name}](/?more-info-entity-id={entity.entity_id})"
+                    if source_uuid == affected:
+                        translation_placeholders["name"] = device_name
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            entry_id,
+            is_fixable=False,
+            is_persistent=True,
+            severity=issue_severity,
+            translation_key="loxone_device_status",
+            translation_placeholders=translation_placeholders,
+            learn_more_url=help_link,
+            data=data,
+        )

--- a/custom_components/loxone/translations/cs.json
+++ b/custom_components/loxone/translations/cs.json
@@ -28,5 +28,15 @@
         }
       }
     }
+  },
+  "issues": {
+    "loxone_status": {
+      "title": "{title}",
+      "description": "{description}"
+    },
+    "loxone_device_status": {
+      "title": "{title}: {name}",
+      "description": "{description}"
+    }
   }
 }

--- a/custom_components/loxone/translations/de.json
+++ b/custom_components/loxone/translations/de.json
@@ -125,5 +125,15 @@
       "name": "Beschattung ",
       "description": "Loxone Jalousie in Schattenposition bringen. Position wird von Loxone abhängig von mehreren Werten festgelegt."
     }
+  },
+  "issues": {
+    "loxone_status": {
+      "title": "{title}",
+      "description": "{description}"
+    },
+    "loxone_device_status": {
+      "title": "{title}: {name}",
+      "description": "{description}"
+    }
   }
 }

--- a/custom_components/loxone/translations/en.json
+++ b/custom_components/loxone/translations/en.json
@@ -135,5 +135,15 @@
       "name": "Quick shade",
       "description": "Move Loxone Jalousie to shade position. Position is set by Loxone depends on multiple values."
     }
+  },
+  "issues": {
+    "loxone_status": {
+      "title": "{title}",
+      "description": "{description}"
+    },
+    "loxone_device_status": {
+      "title": "{title}: {name}",
+      "description": "{description}"
+    }
   }
 }


### PR DESCRIPTION
This adds the message center alerts to appear as issues/repairs in home assistant and they clear when cleared in Loxone.

As a way to test it if you block internet access to the miniserver it will generate a no internet alert between 30 minutes and an hour after blocking it.

```yaml
alias: Notify on New Loxone Repair Issue
description: Sends a notification whenever a new repair issue is registered.
triggers:
  - event_type: repairs_issue_registry_updated
    trigger: event
    event_data:
      action: create
      domain: loxone
conditions: []
actions:
  - data:
      title:  >-
        {% set issue_item = issue(trigger.event.data.domain, trigger.event.data.issue_id) %}
        {{issue_item.translation_placeholders.title }}
        {% if issue_item.translation_placeholders.name %}: {{ issue_item.translation_placeholders.name }}{% endif %}
      message: >-
        {% set issue_item = issue(trigger.event.data.domain, trigger.event.data.issue_id) %}
        {{ issue_item.translation_placeholders.description }}
        {% if issue_item.learn_more_url %}[Loxone Help]({{ issue_item.learn_more_url }}){% endif %}
      data:
        notification_id: '{{ trigger.event.data.issue_id }}'
    action: notify.persistent_notification
mode: parallel
max: 30
```